### PR TITLE
fix: 전수 버그 헌트 — 카테고리별 버그 14건 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ AppPackages/
 #####
 # End of core ignore list, below put you custom 'per project' settings (patterns or path)
 #####
+.worktrees/

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/AlphabetConverterTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/AlphabetConverterTests.cs
@@ -1,0 +1,150 @@
+using System.Numerics;
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// AlphabetConverter 테스트 — 숫자↔알파벳 단위 변환과 역변환
+/// </summary>
+public class AlphabetConverterTests
+{
+    // ===== GetExponent =====
+
+    [TestCase(1000.0, 3L)]
+    [TestCase(999999.0, 3L)]
+    [TestCase(1e6, 6L)]
+    [TestCase(1e9, 9L)]
+    [TestCase(1e21, 21L)]
+    [TestCase(5e10, 9L)]
+    public void GetExponent_ReturnsThreeDigitUnitExponent(double value, long expected)
+    {
+        Assert.That(AlphabetConverter.GetExponent(value), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void GetExponent_BigInteger()
+    {
+        Assert.That(AlphabetConverter.GetExponent(BigInteger.Pow(10, 30)), Is.EqualTo(30L));
+        Assert.That(AlphabetConverter.GetExponent(new BigInteger(1000)), Is.EqualTo(3L));
+    }
+
+    [Test]
+    public void GetExponent_NonPositive_Throws()
+    {
+        // Log10(0)=-Inf, Log10(음수)=NaN이 long 캐스팅을 거치며 쓰레기 지수가 되는 것 방지.
+        // BigInteger 버전(BigInteger.Log10이 throw)과 동작을 맞춘다
+        Assert.Throws<ArgumentOutOfRangeException>(() => AlphabetConverter.GetExponent(0.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => AlphabetConverter.GetExponent(-5.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => AlphabetConverter.GetExponent(double.NaN));
+    }
+
+    // ===== ConvertToAlphabetUnit =====
+
+    [Test]
+    public void ConvertToAlphabetUnit_BelowThousand_ReturnsPlainNumber()
+    {
+        Assert.That(999.0.ConvertToAlphabetUnit(), Is.EqualTo("999"));
+        Assert.That(999.5.ConvertToAlphabetUnit(), Is.EqualTo("999.5"));
+        Assert.That(0.0.ConvertToAlphabetUnit(), Is.EqualTo("0"));
+    }
+
+    [Test]
+    public void ConvertToAlphabetUnit_BasicUnits()
+    {
+        Assert.That(1000.0.ConvertToAlphabetUnit(), Is.EqualTo("1.00A"));
+        Assert.That(1500.0.ConvertToAlphabetUnit(), Is.EqualTo("1.50A"));
+        Assert.That(1e6.ConvertToAlphabetUnit(), Is.EqualTo("1.00B"));
+        Assert.That(2.5e9.ConvertToAlphabetUnit(), Is.EqualTo("2.50C"));
+    }
+
+    [Test]
+    public void ConvertToAlphabetUnit_MaxDecimalPoint()
+    {
+        Assert.That(1234.0.ConvertToAlphabetUnit(0), Is.EqualTo("1A"));
+        Assert.That(1234.0.ConvertToAlphabetUnit(1), Is.EqualTo("1.2A"));
+        Assert.That(1234.0.ConvertToAlphabetUnit(3), Is.EqualTo("1.234A"));
+    }
+
+    [Test]
+    public void ConvertToAlphabetUnit_IntAndFloatOverloads()
+    {
+        Assert.That(2500.ConvertToAlphabetUnit(), Is.EqualTo("2.50A"));
+        Assert.That(1000f.ConvertToAlphabetUnit(), Is.EqualTo("1.00A"));
+        Assert.That(500.ConvertToAlphabetUnit(), Is.EqualTo("500"));
+    }
+
+    // ===== ConvertFromAlphabetUnit (역변환) =====
+
+    [Test]
+    public void ConvertFromAlphabetUnit_BasicUnits()
+    {
+        Assert.That(
+            AlphabetConverter.ConvertFromAlphabetUnit("1.5A"),
+            Is.EqualTo(1500.0).Within(1e-9)
+        );
+        Assert.That(AlphabetConverter.ConvertFromAlphabetUnit("2B"), Is.EqualTo(2e6).Within(1e-3));
+        Assert.That(
+            AlphabetConverter.ConvertFromAlphabetUnit("1AA"),
+            Is.EqualTo(1e81).Within(1e72)
+        );
+    }
+
+    [Test]
+    public void ConvertFromAlphabetUnit_PlainNumber_ParsesDirectly()
+    {
+        Assert.That(AlphabetConverter.ConvertFromAlphabetUnit("123"), Is.EqualTo(123.0));
+        Assert.That(AlphabetConverter.ConvertFromAlphabetUnit("123.45"), Is.EqualTo(123.45));
+    }
+
+    [Test]
+    public void ConvertFromAlphabetUnit_EmptyOrLettersOnly_ReturnsZero()
+    {
+        Assert.That(AlphabetConverter.ConvertFromAlphabetUnit(""), Is.EqualTo(0.0));
+        Assert.That(AlphabetConverter.ConvertFromAlphabetUnit("ABC"), Is.EqualTo(0.0));
+    }
+
+    [Test]
+    public void ConvertFromAlphabetUnit_RoundTripsWithConvertTo()
+    {
+        double[] values = { 1000, 1500, 2.5e6, 7.25e9, 3e12, 9.99e15 };
+        foreach (var value in values)
+        {
+            var str = value.ConvertToAlphabetUnit();
+            var back = AlphabetConverter.ConvertFromAlphabetUnit(str);
+            Assert.That(back, Is.EqualTo(value).Within(value * 0.01), $"'{str}' 라운드트립 실패");
+        }
+    }
+
+    // ===== BigDouble 쪽 알파벳 단위 API =====
+
+    [Test]
+    public void BigDouble_GetExponentFromAlphabetUnit_KnownRanges()
+    {
+        Assert.That(BigDouble.GetExponentFromAlphabetUnit("A"), Is.EqualTo((3L, 5L)));
+        Assert.That(BigDouble.GetExponentFromAlphabetUnit("B"), Is.EqualTo((6L, 8L)));
+        Assert.That(BigDouble.GetExponentFromAlphabetUnit("AA"), Is.EqualTo((81L, 83L)));
+    }
+
+    [Test]
+    public void BigDouble_GetExponentFromAlphabetUnit_Empty_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => BigDouble.GetExponentFromAlphabetUnit(""));
+    }
+
+    [Test]
+    public void BigDouble_GetNumberAndExponentFromUnitName()
+    {
+        Assert.That(BigDouble.GetNumberFromUnitName("A"), Is.EqualTo(1L));
+        Assert.That(BigDouble.GetExponentFromUnitName("A"), Is.EqualTo(3L));
+        Assert.That(BigDouble.GetNumberFromUnitName("B"), Is.EqualTo(2L));
+        Assert.That(BigDouble.GetExponentFromUnitName("B"), Is.EqualTo(6L));
+    }
+
+    [Test]
+    public void BigDouble_GetAlphabetUnit_FromExponent()
+    {
+        Assert.That(BigDouble.GetAlphabetUnit(3), Is.EqualTo("A"));
+        Assert.That(BigDouble.GetAlphabetUnit(6), Is.EqualTo("B"));
+        Assert.That(BigDouble.GetAlphabetUnit(0), Is.EqualTo(string.Empty));
+    }
+}

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/AlphabetManagerTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/AlphabetManagerTests.cs
@@ -1,0 +1,146 @@
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// AlphabetManager 직접 테스트 — 인덱스/단위 변환과 캐시 일관성
+/// </summary>
+public class AlphabetManagerTests
+{
+    // ===== GetAlphabetUnit (index → 단위) =====
+
+    [TestCase(0L, "A")]
+    [TestCase(1L, "B")]
+    [TestCase(25L, "Z")]
+    [TestCase(26L, "AA")]
+    [TestCase(27L, "AB")]
+    [TestCase(51L, "AZ")]
+    [TestCase(52L, "BA")]
+    [TestCase(701L, "ZZ")]
+    [TestCase(702L, "AAA")]
+    [TestCase(703L, "AAB")]
+    public void GetAlphabetUnit_KnownBoundaries(long index, string expected)
+    {
+        Assert.That(AlphabetManager.GetAlphabetUnit(index), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void GetAlphabetUnit_NegativeIndex_ReturnsEmpty()
+    {
+        Assert.That(AlphabetManager.GetAlphabetUnit(-1L), Is.EqualTo(string.Empty));
+        Assert.That(AlphabetManager.GetAlphabetUnit(long.MinValue), Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void GetAlphabetUnit_IntOverload_MatchesLongOverload()
+    {
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.That(
+                AlphabetManager.GetAlphabetUnit(i),
+                Is.EqualTo(AlphabetManager.GetAlphabetUnit((long)i))
+            );
+        }
+    }
+
+    // ===== GetIndexFromUnit (단위 → index) =====
+
+    [TestCase("A", 0L)]
+    [TestCase("Z", 25L)]
+    [TestCase("AA", 26L)]
+    [TestCase("ZZ", 701L)]
+    [TestCase("AAA", 702L)]
+    public void GetIndexFromUnit_KnownBoundaries(string unit, long expected)
+    {
+        Assert.That(AlphabetManager.GetIndexFromUnit(unit), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void GetIndexFromUnit_IsInverseOfGetAlphabetUnit()
+    {
+        for (long i = 0; i < 2000; i++)
+        {
+            var unit = AlphabetManager.GetAlphabetUnit(i);
+            Assert.That(
+                AlphabetManager.GetIndexFromUnit(unit),
+                Is.EqualTo(i),
+                $"index {i} (unit '{unit}') 라운드트립 실패"
+            );
+        }
+    }
+
+    [Test]
+    public void GetIndexFromUnit_LongUnit_NoOverflow()
+    {
+        // 7글자 이상 단위에서 (int)Math.Pow(26, n) 방식은 오버플로가 났던 영역
+        var unit = AlphabetManager.GetAlphabetUnit(10_000_000_000L);
+        Assert.That(AlphabetManager.GetIndexFromUnit(unit), Is.EqualTo(10_000_000_000L));
+    }
+
+    // ===== GetAlphabetUnitFromExponent =====
+
+    [TestCase(0L, "")]
+    [TestCase(1L, "")]
+    [TestCase(2L, "")]
+    [TestCase(3L, "A")]
+    [TestCase(4L, "A")]
+    [TestCase(5L, "A")]
+    [TestCase(6L, "B")]
+    [TestCase(8L, "B")]
+    [TestCase(9L, "C")]
+    [TestCase(78L, "Z")]
+    [TestCase(80L, "Z")]
+    [TestCase(81L, "AA")]
+    public void GetAlphabetUnitFromExponent_KnownBoundaries(long exponent, string expected)
+    {
+        Assert.That(AlphabetManager.GetAlphabetUnitFromExponent(exponent), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void GetAlphabetUnitFromExponent_NegativeExponent_ReturnsEmpty()
+    {
+        Assert.That(AlphabetManager.GetAlphabetUnitFromExponent(-3L), Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void GetAlphabetUnitFromExponent_IntOverload_MatchesLongOverload()
+    {
+        for (int e = 0; e < 300; e++)
+        {
+            Assert.That(
+                AlphabetManager.GetAlphabetUnitFromExponent(e),
+                Is.EqualTo(AlphabetManager.GetAlphabetUnitFromExponent((long)e))
+            );
+        }
+    }
+
+    // ===== 캐시 일관성 =====
+
+    [Test]
+    public void GetAlphabetUnit_RepeatedCalls_ReturnSameResult()
+    {
+        var first = AlphabetManager.GetAlphabetUnit(12345L);
+        var second = AlphabetManager.GetAlphabetUnit(12345L);
+        Assert.That(second, Is.EqualTo(first));
+    }
+
+    [Test]
+    public void GetAlphabetUnit_ConcurrentAccess_IsConsistent()
+    {
+        var failures = 0;
+        Parallel.For(
+            0,
+            5000,
+            i =>
+            {
+                long index = i % 500;
+                var unit = AlphabetManager.GetAlphabetUnit(index);
+                if (AlphabetManager.GetIndexFromUnit(unit) != index)
+                {
+                    Interlocked.Increment(ref failures);
+                }
+            }
+        );
+        Assert.That(failures, Is.EqualTo(0));
+    }
+}

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/BigMathTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/BigMathTests.cs
@@ -1,0 +1,205 @@
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// BigMath 테스트 — 기하/산술 시리즈 비용 계산과 구매 효율
+/// </summary>
+public class BigMathTests
+{
+    // ===== AffordGeometricSeries =====
+
+    [Test]
+    public void AffordGeometricSeries_Basic()
+    {
+        // 가격 1부터 2배씩: 1+2+4+8+16+32 = 63 ≤ 100 < 127 → 6개 구매 가능
+        var affordable = BigMath.AffordGeometricSeries(100, 1, 2, 0);
+        Assert.That(
+            affordable.Equals(new BigDouble(6), 1e-9),
+            Is.True,
+            $"기대 6, 실제 {affordable}"
+        );
+    }
+
+    [Test]
+    public void AffordGeometricSeries_WithCurrentOwned()
+    {
+        // 이미 2개 보유 → 실제 시작가 4: 4+8+16+32 = 60 ≤ 100 < 124 → 4개
+        var affordable = BigMath.AffordGeometricSeries(100, 1, 2, 2);
+        Assert.That(
+            affordable.Equals(new BigDouble(4), 1e-9),
+            Is.True,
+            $"기대 4, 실제 {affordable}"
+        );
+    }
+
+    [Test]
+    public void AffordGeometricSeries_CannotAffordAny()
+    {
+        var affordable = BigMath.AffordGeometricSeries(0.5, 1, 2, 0);
+        Assert.That(
+            affordable.Equals(BigDouble.Zero, 1e-9) || affordable == BigDouble.Zero,
+            Is.True,
+            $"기대 0, 실제 {affordable}"
+        );
+    }
+
+    [Test]
+    public void AffordGeometricSeries_HugeNumbers()
+    {
+        // 1e100 재화, 시작가 1e10, 비율 10 → n = floor(log10(1e90 * 9 + 1)) ≈ 90
+        var affordable = BigMath.AffordGeometricSeries(
+            new BigDouble(1, 100),
+            new BigDouble(1, 10),
+            10,
+            0
+        );
+        Assert.That(
+            affordable.Equals(new BigDouble(90), 1e-9),
+            Is.True,
+            $"기대 90, 실제 {affordable}"
+        );
+    }
+
+    // ===== SumGeometricSeries =====
+
+    [Test]
+    public void SumGeometricSeries_Basic()
+    {
+        // 10 + 20 + 40 = 70
+        var cost = BigMath.SumGeometricSeries(3, 10, 2, 0);
+        Assert.That(cost.Equals(new BigDouble(70), 1e-9), Is.True, $"기대 70, 실제 {cost}");
+    }
+
+    [Test]
+    public void SumGeometricSeries_WithCurrentOwned()
+    {
+        // 1개 보유, 시작가 10, 비율 2 → 실제 시작가 20: 20 + 40 = 60
+        var cost = BigMath.SumGeometricSeries(2, 10, 2, 1);
+        Assert.That(cost.Equals(new BigDouble(60), 1e-9), Is.True, $"기대 60, 실제 {cost}");
+    }
+
+    [Test]
+    public void SumGeometricSeries_RatioOne_IsLinearCost()
+    {
+        // 비율 1이면 가격이 고정 — 10짜리 5개 = 50 (1-ratio 0 나눗셈으로 NaN이 되면 안 됨)
+        var cost = BigMath.SumGeometricSeries(5, 10, 1, 0);
+        Assert.That(cost.Equals(new BigDouble(50), 1e-9), Is.True, $"기대 50, 실제 {cost}");
+    }
+
+    [Test]
+    public void AffordGeometricSeries_RatioOne_IsLinearAfford()
+    {
+        // 비율 1이면 고정가 10짜리를 100으로 정확히 10개
+        var affordable = BigMath.AffordGeometricSeries(100, 10, 1, 3);
+        Assert.That(
+            affordable.Equals(new BigDouble(10), 1e-9),
+            Is.True,
+            $"기대 10, 실제 {affordable}"
+        );
+    }
+
+    [Test]
+    public void SumAndAfford_GeometricSeries_AreConsistent()
+    {
+        // Sum으로 계산한 비용만큼 주면 정확히 그 개수를 살 수 있어야 함
+        BigDouble priceStart = 5;
+        BigDouble ratio = 1.5;
+        BigDouble owned = 3;
+        BigDouble count = 7;
+
+        // 정확한 경계값은 log/floor 오차로 한 개 아래로 떨어질 수 있어 약간의 버퍼를 줌
+        var cost = BigMath.SumGeometricSeries(count, priceStart, ratio, owned) * 1.000001;
+        var affordable = BigMath.AffordGeometricSeries(cost, priceStart, ratio, owned);
+        Assert.That(affordable.Equals(count, 1e-6), Is.True, $"기대 {count}, 실제 {affordable}");
+    }
+
+    // ===== AffordArithmeticSeries =====
+
+    [Test]
+    public void AffordArithmeticSeries_Basic()
+    {
+        // 10+15+20+25+30 = 100 → 정확히 5개
+        var affordable = BigMath.AffordArithmeticSeries(100, 10, 5, 0);
+        Assert.That(
+            affordable.Equals(new BigDouble(5), 1e-9),
+            Is.True,
+            $"기대 5, 실제 {affordable}"
+        );
+    }
+
+    [Test]
+    public void AffordArithmeticSeries_WithCurrentOwned()
+    {
+        // 2개 보유 → 시작가 20: 20+25 = 45 ≤ 50 < 75 → 2개
+        var affordable = BigMath.AffordArithmeticSeries(50, 10, 5, 2);
+        Assert.That(
+            affordable.Equals(new BigDouble(2), 1e-9),
+            Is.True,
+            $"기대 2, 실제 {affordable}"
+        );
+    }
+
+    // ===== SumArithmeticSeries =====
+
+    [Test]
+    public void SumArithmeticSeries_Basic()
+    {
+        // 10+15+20+25 = 70
+        var cost = BigMath.SumArithmeticSeries(4, 10, 5, 0);
+        Assert.That(cost.Equals(new BigDouble(70), 1e-9), Is.True, $"기대 70, 실제 {cost}");
+    }
+
+    [Test]
+    public void SumAndAfford_ArithmeticSeries_AreConsistent()
+    {
+        BigDouble priceStart = 100;
+        BigDouble priceAdd = 25;
+        BigDouble owned = 4;
+        BigDouble count = 10;
+
+        // 정확한 경계값은 sqrt/floor 오차로 한 개 아래로 떨어질 수 있어 약간의 버퍼를 줌
+        var cost = BigMath.SumArithmeticSeries(count, priceStart, priceAdd, owned) * 1.000001;
+        var affordable = BigMath.AffordArithmeticSeries(cost, priceStart, priceAdd, owned);
+        Assert.That(affordable.Equals(count, 1e-6), Is.True, $"기대 {count}, 실제 {affordable}");
+    }
+
+    // ===== EfficiencyOfPurchase =====
+
+    [Test]
+    public void EfficiencyOfPurchase_Basic()
+    {
+        // 10/100 + 10/1 = 10.1
+        var efficiency = BigMath.EfficiencyOfPurchase(10, 100, 1);
+        Assert.That(
+            efficiency.Equals(new BigDouble(10.1), 1e-9),
+            Is.True,
+            $"기대 10.1, 실제 {efficiency}"
+        );
+    }
+
+    [Test]
+    public void EfficiencyOfPurchase_LowerIsBetter()
+    {
+        // 같은 비용이면 RpS 증가가 큰 쪽이 효율 점수가 낮아야 함
+        var better = BigMath.EfficiencyOfPurchase(100, 50, 20);
+        var worse = BigMath.EfficiencyOfPurchase(100, 50, 5);
+        Assert.That(better < worse, Is.True);
+    }
+
+    // ===== RandomBigDouble =====
+
+    [Test]
+    public void RandomBigDouble_AlwaysNormalized()
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            var value = BigMath.RandomBigDouble(100);
+            Assert.That(BigDouble.IsNaN(value), Is.False);
+
+            var m = Math.Abs(value.Mantissa);
+            bool normalized = m == 0 || (m >= 1 && m < 10);
+            Assert.That(normalized, Is.True, $"정규화 위반: {value.ToStringMantissaExponent()}");
+        }
+    }
+}

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/BigValueInfoTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/BigValueInfoTests.cs
@@ -1,0 +1,75 @@
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// BigValueInfo.ExponentFormatToBigValueInfo 직접 테스트 — e 표기법 수동 파서
+/// </summary>
+public class BigValueInfoTests
+{
+    [Test]
+    public void Parse_BasicExponentFormat()
+    {
+        var info = BigValueInfo.ExponentFormatToBigValueInfo("1.5e3");
+        Assert.That(info.Mantissa, Is.EqualTo(1.5).Within(1e-15));
+        Assert.That(info.Exponent, Is.EqualTo(3L));
+    }
+
+    [Test]
+    public void Parse_UppercaseE()
+    {
+        var info = BigValueInfo.ExponentFormatToBigValueInfo("2E10");
+        Assert.That(info.Mantissa, Is.EqualTo(2.0).Within(1e-15));
+        Assert.That(info.Exponent, Is.EqualTo(10L));
+    }
+
+    [Test]
+    public void Parse_NegativeMantissaAndExponent()
+    {
+        var info = BigValueInfo.ExponentFormatToBigValueInfo("-2.5e-10");
+        Assert.That(info.Mantissa, Is.EqualTo(-2.5).Within(1e-15));
+        Assert.That(info.Exponent, Is.EqualTo(-10L));
+    }
+
+    [Test]
+    public void Parse_ExplicitPlusSigns()
+    {
+        var info = BigValueInfo.ExponentFormatToBigValueInfo("+3e+5");
+        Assert.That(info.Mantissa, Is.EqualTo(3.0).Within(1e-15));
+        Assert.That(info.Exponent, Is.EqualTo(5L));
+    }
+
+    [Test]
+    public void Parse_NoExponentPart_ExponentIsZero()
+    {
+        var info = BigValueInfo.ExponentFormatToBigValueInfo("42");
+        Assert.That(info.Mantissa, Is.EqualTo(42.0));
+        Assert.That(info.Exponent, Is.EqualTo(0L));
+
+        info = BigValueInfo.ExponentFormatToBigValueInfo("1.25");
+        Assert.That(info.Mantissa, Is.EqualTo(1.25).Within(1e-15));
+        Assert.That(info.Exponent, Is.EqualTo(0L));
+    }
+
+    [Test]
+    public void Parse_VeryLargeExponent()
+    {
+        var info = BigValueInfo.ExponentFormatToBigValueInfo("1e999999999");
+        Assert.That(info.Exponent, Is.EqualTo(999999999L));
+    }
+
+    [TestCase("")]
+    [TestCase(null)]
+    [TestCase("e5")] // 가수 없음
+    [TestCase("1e")] // 지수 숫자 없음
+    [TestCase("1.2.3")] // 소수점 중복
+    [TestCase("1e5e3")] // e 중복
+    [TestCase("1e2.5")] // 지수에 소수점
+    [TestCase("1-2e5")] // 부호가 가운데
+    [TestCase("12x")] // 숫자가 아닌 문자
+    [TestCase("1e92233720368547758079")] // long 오버플로
+    public void Parse_InvalidInput_ThrowsFormatException(string? input)
+    {
+        Assert.Throws<FormatException>(() => BigValueInfo.ExponentFormatToBigValueInfo(input!));
+    }
+}

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/BugHuntRegressionTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/BugHuntRegressionTests.cs
@@ -1,0 +1,171 @@
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// 전수 버그 헌트(2차 리뷰)에서 발견된 버그들의 회귀 테스트
+/// </summary>
+public class BugHuntRegressionTests
+{
+    // ===== H1: Cbrt가 3의 배수가 아닌 음수 지수에서 보정 상수(10^(1/3), 10^(2/3))를
+    //           뒤바꿔 곱하던 버그 — C# %의 음수 나머지를 잉여류로 오용 =====
+
+    [Test]
+    public void Cbrt_NegativeExponent()
+    {
+        Assert.That(
+            BigDouble.Cbrt(new BigDouble(1e-4)).ToDouble(),
+            Is.EqualTo(Math.Cbrt(1e-4)).Within(1e-16)
+        );
+        Assert.That(
+            BigDouble.Cbrt(new BigDouble(-1e-2)).ToDouble(),
+            Is.EqualTo(Math.Cbrt(-1e-2)).Within(1e-16)
+        );
+    }
+
+    [Test]
+    public void Cbrt_PowerOfTenSweep()
+    {
+        for (int e = -30; e <= 30; e++)
+        {
+            double expected = Math.Cbrt(Math.Pow(10, e));
+            Assert.That(
+                BigDouble.Cbrt(BigDouble.Pow10((long)e)).ToDouble(),
+                Is.EqualTo(expected).Within(Math.Abs(expected) * 1e-12),
+                $"Cbrt(1e{e})"
+            );
+        }
+    }
+
+    // ===== H2: Normalize가 subnormal 구간(약 1e-323~1e-309)에서 Log10 오차로
+    //           mantissa >= 10인 비정규 값을 만들어 ToDouble이 한 자릿수 어긋남 =====
+
+    [Test]
+    public void Normalize_Subnormal_KeepsMantissaInvariant()
+    {
+        var a = new BigDouble(1e-323);
+        Assert.That(a.Mantissa, Is.GreaterThanOrEqualTo(1).And.LessThan(10));
+        Assert.That(a.ToDouble(), Is.EqualTo(1e-323));
+
+        var b = new BigDouble(1e-322);
+        Assert.That(b.Mantissa, Is.GreaterThanOrEqualTo(1).And.LessThan(10));
+        Assert.That(b.ToDouble(), Is.EqualTo(1e-322));
+
+        // 기존 특수처리(최소 subnormal) 회귀 확인
+        Assert.That(new BigDouble(5e-324).ToDouble(), Is.EqualTo(5e-324));
+    }
+
+    // ===== H3/H4: NaN의 지수가 long.MinValue 센티널이라 지수 연산 오버플로 핸들러가
+    //              NaN을 Zero/Infinity로 둔갑시키던 버그 =====
+
+    [Test]
+    public void Multiply_NaN_Propagates()
+    {
+        Assert.That(BigDouble.IsNaN(BigDouble.NaN * new BigDouble(0.5)), Is.True);
+        Assert.That(BigDouble.IsNaN(new BigDouble(0.5) * BigDouble.NaN), Is.True);
+    }
+
+    [Test]
+    public void Pow_NaN_Propagates()
+    {
+        Assert.That(BigDouble.IsNaN(BigDouble.Pow(BigDouble.NaN, 2L)), Is.True);
+    }
+
+    // ===== H5: Pow(음수 밑, 큰 홀수 long 지수)에서 mantissa^power 오버플로 시
+    //           제곱 후 재귀하면서 부호가 사라지던 버그 =====
+
+    [Test]
+    public void Pow_NegativeBase_LargeOddPower_KeepsSign()
+    {
+        var result = BigDouble.Pow(new BigDouble(-9), 401L);
+        Assert.That(result.Mantissa, Is.LessThan(0));
+        Assert.That(result.Exponent, Is.EqualTo(382));
+        Assert.That(result.Mantissa, Is.EqualTo(-4.4796727106).Within(1e-4));
+
+        // 짝수 지수는 양수 유지
+        Assert.That(BigDouble.Pow(new BigDouble(-9), 400L).Mantissa, Is.GreaterThan(0));
+    }
+
+    // ===== H6: Log(x, base=1)이 0으로 나누기를 타고 Infinity 반환 (Math.Log는 NaN) =====
+
+    [Test]
+    public void Log_BaseOne_IsNaN()
+    {
+        Assert.That(double.IsNaN(BigDouble.Log(new BigDouble(100), 1.0)), Is.True);
+    }
+
+    // ===== H7: Equals는 모든 zero를 같다고 보는데 GetHashCode는 지수를 섞어
+    //           해시 계약(같으면 해시도 같다)을 위반 =====
+
+    [Test]
+    public void GetHashCode_AllZerosShareHash()
+    {
+        var z1 = BigDouble.Zero;
+        var z2 = BigDouble.FromMantissaExponentNoNormalize(0, 5);
+        Assert.That(z1.Equals(z2), Is.True);
+        Assert.That(z1.GetHashCode(), Is.EqualTo(z2.GetHashCode()));
+    }
+
+    // ===== H8: ToString에서 가수 반올림이 1000에 도달해도 알파벳 단위가 안 올라가
+    //           "1000G"(가수 4자리) 표기가 나오던 버그 =====
+
+    [Test]
+    public void ToString_MantissaRoundingCarriesUnit()
+    {
+        Assert.That(new BigDouble("9.999999e23").ToString(), Is.EqualTo("1.00H"));
+    }
+
+    // ===== H9: ConvertToAlphabetUnit의 F-포맷 반올림이 1000으로 올라가도 단위 미갱신 =====
+
+    [Test]
+    public void ConvertToAlphabetUnit_RoundingCarriesUnit()
+    {
+        Assert.That(999999.0.ConvertToAlphabetUnit(), Is.EqualTo("1.00B"));
+        Assert.That(999994.0.ConvertToAlphabetUnit(), Is.EqualTo("999.99A"));
+    }
+
+    // ===== H10: 음수 값에 알파벳 단위가 전혀 안 붙던 버그 =====
+
+    [Test]
+    public void ConvertToAlphabetUnit_NegativeValues()
+    {
+        Assert.That((-5000.0).ConvertToAlphabetUnit(), Is.EqualTo("-5.00A"));
+        Assert.That((-1500000.0).ConvertToAlphabetUnit(), Is.EqualTo("-1.50B"));
+        Assert.That((-500.0).ConvertToAlphabetUnit(), Is.EqualTo("-500"));
+    }
+
+    // ===== H11: 소문자 단위가 c-'A' 계산을 그대로 타서 "1.5a"가 1.5e99로 둔갑 =====
+
+    [Test]
+    public void ConvertFromAlphabetUnit_LowercaseUnit_Throws()
+    {
+        Assert.Throws<FormatException>(() => AlphabetConverter.ConvertFromAlphabetUnit("1.5a"));
+    }
+
+    // ===== H12: AdjustedMantissa가 음수 지수에서 3자리 보정을 적용해 0.5를 500으로 =====
+
+    [Test]
+    public void AdjustedMantissa_NegativeExponent_ReturnsActualValue()
+    {
+        Assert.That(new BigDouble(0.5).AdjustedMantissa(), Is.EqualTo(0.5));
+    }
+
+    // ===== H13/H14: GetDigits의 int 캐스팅 포화 — 큰 음수는 크래시, 21억 초과는 오답 =====
+
+    [Test]
+    public void GetDigits_LargeNegative_NoCrash()
+    {
+        Assert.That(NumberUtility.GetDigits(-3e9), Is.EqualTo(10));
+        Assert.That(NumberUtility.GetDigits(int.MinValue), Is.EqualTo(10));
+    }
+
+    [Test]
+    public void GetDigits_BeyondIntRange()
+    {
+        Assert.That(NumberUtility.GetDigits(1e10), Is.EqualTo(11));
+        Assert.That(NumberUtility.GetDigits(1e15), Is.EqualTo(16));
+        // 기존 동작 회귀 확인
+        Assert.That(NumberUtility.GetDigits(999.0), Is.EqualTo(3));
+        Assert.That(NumberUtility.GetDigits(0.5), Is.EqualTo(0));
+    }
+}

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/ComplexGameScenarioTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/ComplexGameScenarioTests.cs
@@ -1,0 +1,251 @@
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// 골드를 복잡한 연산 체인(곱셈/덧셈/뺄셈/나눗셈)으로 굴려 거대한 값을 만든 뒤,
+/// 보유 골드와 거의 일치하는 가격의 아이템을 구매할 때 판정이 어긋나지 않는지 검증.
+/// "분명 돈이 더 많은데 못 사는" 류의 비교/연산 불일치를 잡기 위한 테스트.
+/// </summary>
+public class ComplexGameScenarioTests
+{
+    /// <summary>
+    /// 비교 연산자 삼분법 검증: 두 값에 대해 &lt;, ==, &gt; 중 정확히 하나만 참이어야 하고
+    /// &gt;=, &lt;=, CompareTo가 모두 그 결과와 일치해야 함.
+    /// </summary>
+    private static void AssertOrderingConsistent(BigDouble a, BigDouble b)
+    {
+        bool lt = a < b;
+        bool gt = a > b;
+        bool eq = a == b;
+
+        int trueCount = (lt ? 1 : 0) + (gt ? 1 : 0) + (eq ? 1 : 0);
+        Assert.That(trueCount, Is.EqualTo(1), $"삼분법 위반: lt={lt}, gt={gt}, eq={eq}");
+
+        Assert.That(a >= b, Is.EqualTo(gt || eq), ">= 는 (> 또는 ==)와 일치해야 함");
+        Assert.That(a <= b, Is.EqualTo(lt || eq), "<= 는 (< 또는 ==)와 일치해야 함");
+
+        int expectedSign =
+            lt ? -1
+            : gt ? 1
+            : 0;
+        Assert.That(Math.Sign(a.CompareTo(b)), Is.EqualTo(expectedSign), "CompareTo 부호 불일치");
+    }
+
+    /// <summary>
+    /// money >= price 라면 반드시 구매가 가능해야 하고, 잔액이 음수가 되면 안 됨.
+    /// </summary>
+    private static void AssertPurchasable(BigDouble money, BigDouble price)
+    {
+        Assert.That(money >= price, Is.True, "money >= price 인데 구매 판정 실패");
+
+        BigDouble remaining = money - price;
+        Assert.That(
+            remaining >= BigDouble.Zero,
+            Is.True,
+            $"구매 후 잔액이 음수: {remaining.ToStringMantissaExponent()}"
+        );
+        Assert.That(remaining <= money, Is.True, "잔액이 원금보다 클 수 없음");
+    }
+
+    [Test]
+    public void Purchase_ExactPrice_AfterLongOperationChain()
+    {
+        // 동일한 연산 체인으로 돈과 가격을 각각 계산 → 정확히 같아야 하고 전액 구매 가능
+        static BigDouble BuildValue()
+        {
+            BigDouble v = new BigDouble(1234.5678);
+            v *= new BigDouble("7.77e77");
+            v += new BigDouble("3.33e70");
+            v -= new BigDouble("1.11e65");
+            v /= 13;
+            v *= new BigDouble("9.99e999");
+            v += v / 3;
+            return v;
+        }
+
+        BigDouble money = BuildValue();
+        BigDouble price = BuildValue();
+
+        Assert.That(money == price, Is.True, "같은 체인으로 계산한 값은 같아야 함");
+        AssertPurchasable(money, price);
+
+        BigDouble remaining = money - price;
+        Assert.That(remaining == BigDouble.Zero, Is.True, "전액 구매 후 잔액은 0");
+    }
+
+    [Test]
+    public void Purchase_CommutedComputation_SamePrice()
+    {
+        // 곱셈 교환은 IEEE에서도 비트 단위로 동일 → 다른 순서로 계산해도 같아야 함
+        BigDouble a = new BigDouble("1.7320508e500");
+        BigDouble b = new BigDouble("2.7182818e300");
+        BigDouble c = new BigDouble("3.1415926e799");
+
+        BigDouble money = a * b + c;
+        BigDouble price = c + b * a;
+
+        Assert.That(money == price, Is.True, "교환법칙이 성립하는 식은 같은 값");
+        AssertPurchasable(money, price);
+        Assert.That(money - price == BigDouble.Zero, Is.True);
+    }
+
+    [Test]
+    public void Purchase_AssociativityDrift_JudgmentStaysConsistent()
+    {
+        // (a+b)+c 와 a+(b+c)는 부동소수점 특성상 미세하게 다를 수 있음.
+        // 핵심은 "다르더라도 비교 판정이 모순되지 않는 것" — 작은 쪽 가격은 큰 쪽 돈으로 반드시 구매 가능.
+        BigDouble a = new BigDouble("1.111111111111111e1000");
+        BigDouble b = new BigDouble("7.777777777777777e999");
+        BigDouble c = new BigDouble("3.333333333333333e998");
+
+        BigDouble money = a + b + c;
+        BigDouble price = a + (b + c);
+
+        AssertOrderingConsistent(money, price);
+        Assert.That(money.Equals(price, 1e-9), Is.True, "결합 순서 차이는 1e-9 이내");
+
+        BigDouble bigger = BigDouble.Max(money, price);
+        BigDouble smaller = BigDouble.Min(money, price);
+        AssertPurchasable(bigger, smaller);
+    }
+
+    [Test]
+    public void Purchase_SlightlyCheaperItem_AlwaysBuyable()
+    {
+        // 가격이 돈보다 아주 미세하게(상대 1e-12) 싸면 반드시 구매 가능해야 함
+        BigDouble money = new BigDouble("5.5555e5555");
+        BigDouble price = money * new BigDouble(1.0 - 1e-12);
+
+        Assert.That(price < money, Is.True, "가격이 미세하게 싸야 함");
+        AssertPurchasable(money, price);
+
+        BigDouble remaining = money - price;
+        Assert.That(remaining > BigDouble.Zero, Is.True, "잔액은 0보다 커야 함");
+        Assert.That(
+            remaining.Equals(money * new BigDouble(1e-12), 1e-3),
+            Is.True,
+            $"잔액은 대략 money*1e-12: {remaining.ToStringMantissaExponent()}"
+        );
+    }
+
+    [Test]
+    public void Purchase_SlightlyMoreExpensiveItem_NeverBuyable()
+    {
+        // 가격이 돈보다 미세하게(상대 1e-12) 비싸면 절대 구매 불가
+        BigDouble money = new BigDouble("5.5555e5555");
+        BigDouble price = money * new BigDouble(1.0 + 1e-12);
+
+        Assert.That(money < price, Is.True, "돈이 미세하게 부족");
+        Assert.That(money >= price, Is.False, "구매 가능으로 잘못 판정되면 안 됨");
+        AssertOrderingConsistent(money, price);
+    }
+
+    [Test]
+    public void Purchase_FullSpend_RepeatedEarnAndDrain()
+    {
+        // 매번 다른 연산 체인으로 돈을 벌고, 전액과 일치하는 가격으로 모두 소진 — 항상 0으로 떨어져야 함
+        BigDouble money = BigDouble.Zero;
+
+        for (int i = 1; i <= 30; i++)
+        {
+            BigDouble earned = new BigDouble(1.0 + i * 0.137, i * 100);
+            earned *= new BigDouble(2.5, i * 7);
+            earned += new BigDouble(9.9, i * 50);
+            earned /= 3;
+
+            money += earned;
+            BigDouble price = money; // 보유 전액과 동일한 가격
+
+            AssertPurchasable(money, price);
+            money -= price;
+
+            Assert.That(money == BigDouble.Zero, Is.True, $"{i}회차 전액 구매 후 잔액은 0");
+        }
+    }
+
+    [Test]
+    public void Purchase_HalfDrain_NeverGoesNegative()
+    {
+        // 성장(곱셈+수입)과 절반 지출을 반복 — 잔액이 음수가 되거나 판정이 어긋나면 안 됨
+        BigDouble money = new BigDouble("1e10");
+        BigDouble income = new BigDouble("3.7e9");
+
+        for (int i = 0; i < 200; i++)
+        {
+            money = money * new BigDouble(1.07) + income;
+
+            BigDouble price = money / 2;
+            Assert.That(money >= price, Is.True, $"{i}회차: 절반 가격은 항상 구매 가능");
+
+            money -= price;
+            Assert.That(money >= BigDouble.Zero, Is.True, $"{i}회차: 잔액 음수");
+            AssertOrderingConsistent(money, price);
+        }
+    }
+
+    [Test]
+    public void Purchase_AccumulatedIncome_VsBulkPrice()
+    {
+        // 수입을 1000번 누적한 돈 vs (수입 * 1000)으로 책정된 가격.
+        // 부동소수점 누적 오차로 미세하게 다를 수 있지만, 판정은 모순 없어야 하고 차이는 극미해야 함
+        BigDouble income = new BigDouble(1.23456789, 45);
+        BigDouble money = BigDouble.Zero;
+
+        for (int i = 0; i < 1000; i++)
+        {
+            money += income;
+        }
+
+        BigDouble price = income * 1000;
+
+        Assert.That(money.Equals(price, 1e-9), Is.True, "누적합과 일괄 곱은 1e-9 이내로 일치");
+        AssertOrderingConsistent(money, price);
+
+        BigDouble bigger = BigDouble.Max(money, price);
+        BigDouble smaller = BigDouble.Min(money, price);
+        AssertPurchasable(bigger, smaller);
+    }
+
+    [Test]
+    public void Purchase_DivideMultiplyRoundTrip()
+    {
+        // 가격을 money/7*7 로 책정 — 왕복 연산 오차가 있어도 판정은 일관돼야 함
+        BigDouble money = new BigDouble("8.8888888888888e8888");
+        BigDouble price = money / 7 * 7;
+
+        Assert.That(money.Equals(price, 1e-12), Is.True, "나눗셈 왕복 오차는 1e-12 이내");
+        AssertOrderingConsistent(money, price);
+
+        if (money >= price)
+        {
+            AssertPurchasable(money, price);
+        }
+        else
+        {
+            // 왕복 오차로 가격이 미세하게 비싸진 경우 — 부족분은 상대 1e-12 미만이어야 함
+            BigDouble shortfall = price - money;
+            Assert.That(
+                shortfall < money * new BigDouble(1e-12),
+                Is.True,
+                $"부족분이 비정상적으로 큼: {shortfall.ToStringMantissaExponent()}"
+            );
+        }
+    }
+
+    [Test]
+    public void Purchase_NearEqualAtHugeExponent()
+    {
+        // 거대 지수(e100000)에서 마지막 유효숫자 한 끗 차이의 구매 판정
+        BigDouble money = new BigDouble("1.000000000000001e100000");
+        BigDouble priceCheaper = new BigDouble("1.000000000000000e100000");
+        BigDouble priceExpensive = new BigDouble("1.000000000000002e100000");
+
+        AssertPurchasable(money, priceCheaper);
+        Assert.That(money >= priceExpensive, Is.False, "더 비싼 아이템은 구매 불가");
+
+        AssertOrderingConsistent(money, priceCheaper);
+        AssertOrderingConsistent(money, priceExpensive);
+        AssertOrderingConsistent(money, money);
+    }
+}

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/ConversionTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/ConversionTests.cs
@@ -1,0 +1,237 @@
+using System.Numerics;
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// BigDouble 변환 테스트 — 암묵/명시적 변환, ToDouble/ToFloat 경계, 생성자, 해시/동등성 계약
+/// </summary>
+public class ConversionTests
+{
+    // ===== 암묵적 변환 =====
+
+    [Test]
+    public void ImplicitConversion_FromNumericTypes()
+    {
+        BigDouble fromInt = 42;
+        BigDouble fromLong = 42L;
+        BigDouble fromFloat = 42f;
+        BigDouble fromDouble = 42.0;
+
+        Assert.That(fromInt == fromLong, Is.True);
+        Assert.That(fromLong == fromFloat, Is.True);
+        Assert.That(fromFloat == fromDouble, Is.True);
+    }
+
+    [Test]
+    public void ImplicitConversion_FromString()
+    {
+        BigDouble fromString = "1e100";
+        Assert.That(fromString == new BigDouble(1, 100), Is.True);
+    }
+
+    [Test]
+    public void ExplicitConversion_FromBigInteger()
+    {
+        var big = (BigDouble)new BigInteger(12345);
+        Assert.That(big == new BigDouble(12345), Is.True);
+    }
+
+    [Test]
+    public void ImplicitConversion_SpecialDoubles()
+    {
+        BigDouble nan = double.NaN;
+        BigDouble posInf = double.PositiveInfinity;
+        BigDouble negInf = double.NegativeInfinity;
+
+        Assert.That(BigDouble.IsNaN(nan), Is.True);
+        Assert.That(BigDouble.IsPositiveInfinity(posInf), Is.True);
+        Assert.That(BigDouble.IsNegativeInfinity(negInf), Is.True);
+    }
+
+    // ===== 생성자 =====
+
+    [Test]
+    public void Constructor_StringWithExponent()
+    {
+        Assert.That(new BigDouble("1.5e3") == new BigDouble(1500), Is.True);
+        Assert.That(new BigDouble("1E10") == new BigDouble(1, 10), Is.True);
+    }
+
+    [Test]
+    public void Constructor_StringPlainNumber()
+    {
+        Assert.That(new BigDouble("123") == new BigDouble(123), Is.True);
+    }
+
+    [Test]
+    public void Constructor_StringNaN()
+    {
+        Assert.That(BigDouble.IsNaN(new BigDouble("NaN")), Is.True);
+    }
+
+    [Test]
+    public void Constructor_ExplicitFormat()
+    {
+        var withExponent = new BigDouble("2.5e6", BigDouble.eFormat.NumberWithExponent);
+        Assert.That(withExponent == new BigDouble(2.5, 6), Is.True);
+
+        var plainNumber = new BigDouble("2500", BigDouble.eFormat.Number);
+        Assert.That(plainNumber == new BigDouble(2500), Is.True);
+    }
+
+    [Test]
+    public void Constructor_Copy()
+    {
+        var original = new BigDouble(3.14, 50);
+        var copy = new BigDouble(original);
+        Assert.That(copy == original, Is.True);
+        Assert.That(copy.Mantissa, Is.EqualTo(original.Mantissa));
+        Assert.That(copy.Exponent, Is.EqualTo(original.Exponent));
+    }
+
+    [Test]
+    public void Parse_InvalidPlainString_Throws()
+    {
+        Assert.Throws<FormatException>(() => BigDouble.Parse("abc"));
+    }
+
+    [Test]
+    public void Parse_NullString_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => BigDouble.Parse(null!));
+        Assert.Throws<ArgumentNullException>(() => new BigDouble((string)null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            new BigDouble((string)null!, BigDouble.eFormat.Number)
+        );
+    }
+
+    [Test]
+    public void CompareTo_NullLiteral_ResolvesToStringConversion_ThrowsClearException()
+    {
+        // 캐스트 없는 null 리터럴은 implicit string→BigDouble 변환을 타는 오버로드로 해석됨.
+        // NRE 대신 ArgumentNullException이 나와야 함. object로 캐스트하면 CompareTo(object)로 감.
+        Assert.Throws<ArgumentNullException>(() => new BigDouble(5).CompareTo(null));
+    }
+
+    // ===== ToDouble 경계 =====
+
+    [Test]
+    public void ToDouble_ExponentAboveDoubleRange_ReturnsInfinity()
+    {
+        var positive = BigDouble.FromMantissaExponentNoNormalize(1, 309);
+        var negative = BigDouble.FromMantissaExponentNoNormalize(-1, 309);
+        Assert.That(positive.ToDouble(), Is.EqualTo(double.PositiveInfinity));
+        Assert.That(negative.ToDouble(), Is.EqualTo(double.NegativeInfinity));
+    }
+
+    [Test]
+    public void ToDouble_ExponentBelowDoubleRange_ReturnsZero()
+    {
+        var tiny = BigDouble.FromMantissaExponentNoNormalize(1, -325);
+        Assert.That(tiny.ToDouble(), Is.EqualTo(0.0));
+    }
+
+    [Test]
+    public void ToDouble_DenormalBoundary()
+    {
+        // -324 지수는 5e-324(비정규화 최솟값)로 별도 처리됨
+        var positive = BigDouble.FromMantissaExponentNoNormalize(1, -324);
+        var negative = BigDouble.FromMantissaExponentNoNormalize(-1, -324);
+        Assert.That(positive.ToDouble(), Is.EqualTo(5e-324));
+        Assert.That(negative.ToDouble(), Is.EqualTo(-5e-324));
+    }
+
+    [Test]
+    public void ToDouble_IntegerValues_RoundTripExactly()
+    {
+        Assert.That(new BigDouble(123456789).ToDouble(), Is.EqualTo(123456789.0));
+        Assert.That(new BigDouble(-42).ToDouble(), Is.EqualTo(-42.0));
+    }
+
+    [Test]
+    public void ToDouble_NaN()
+    {
+        Assert.That(BigDouble.NaN.ToDouble(), Is.EqualTo(double.NaN));
+    }
+
+    [Test]
+    public void ToFloat_BeyondFloatRange_ReturnsInfinity()
+    {
+        Assert.That(new BigDouble(1, 100).ToFloat(), Is.EqualTo(float.PositiveInfinity));
+        Assert.That(new BigDouble(-1, 100).ToFloat(), Is.EqualTo(float.NegativeInfinity));
+    }
+
+    [Test]
+    public void ToFloat_NormalRange()
+    {
+        Assert.That(new BigDouble(1.5, 10).ToFloat(), Is.EqualTo(1.5e10f).Within(1e4f));
+    }
+
+    // ===== ToStringMantissaExponent =====
+
+    [Test]
+    public void ToStringMantissaExponent_Format()
+    {
+        Assert.That(new BigDouble(1.5, 100).ToStringMantissaExponent(), Is.EqualTo("1.5e100"));
+        Assert.That(BigDouble.Zero.ToStringMantissaExponent(), Is.EqualTo("0e0"));
+    }
+
+    // ===== Equals(object) / GetHashCode / CompareTo(object) 계약 =====
+
+    [Test]
+    public void EqualsObject_NonBigDouble_ReturnsFalse()
+    {
+        // 캐스트 없이 넘기면 implicit 변환 때문에 Equals(BigDouble) 오버로드로 가버림
+        Assert.That(new BigDouble(5).Equals((object)"5"), Is.False);
+        Assert.That(new BigDouble(5).Equals((object?)null), Is.False);
+        Assert.That(
+            new BigDouble(5).Equals((object)5.0),
+            Is.False,
+            "박싱된 double은 BigDouble이 아님"
+        );
+    }
+
+    [Test]
+    public void EqualsObject_BoxedBigDouble()
+    {
+        object boxed = new BigDouble(5);
+        Assert.That(new BigDouble(5).Equals(boxed), Is.True);
+    }
+
+    [Test]
+    public void GetHashCode_EqualValues_HaveEqualHashes()
+    {
+        // 10e99와 1e100은 정규화 후 같은 값
+        var a = new BigDouble(10, 99);
+        var b = new BigDouble(1, 100);
+        Assert.That(a == b, Is.True);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void GetHashCode_DefaultEqualsZero()
+    {
+        Assert.That(default(BigDouble) == BigDouble.Zero, Is.True);
+        Assert.That(default(BigDouble).GetHashCode(), Is.EqualTo(BigDouble.Zero.GetHashCode()));
+    }
+
+    [Test]
+    public void CompareToObject_Null_ReturnsPositive()
+    {
+        Assert.That(new BigDouble(5).CompareTo((object?)null), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void CompareToObject_WrongType_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new BigDouble(5).CompareTo((object)"5"));
+    }
+
+    [Test]
+    public void CompareToObject_BoxedBigDouble()
+    {
+        object boxed = new BigDouble(10);
+        Assert.That(new BigDouble(5).CompareTo(boxed), Is.EqualTo(-1));
+    }
+}

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/ExtendedMathTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/ExtendedMathTests.cs
@@ -1,0 +1,326 @@
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// BigDouble 확장 수학 함수 테스트 — Abs/Negate/Sign/Reciprocate/Cbrt/Exp/Factorial/
+/// 쌍곡함수/로그 변형/Pow 엣지/증감 연산자
+/// </summary>
+public class ExtendedMathTests
+{
+    // ===== Abs / Negate / Sign =====
+
+    [Test]
+    public void Abs_NegativeAndPositive()
+    {
+        Assert.That(BigDouble.Abs(new BigDouble(-5, 100)) == new BigDouble(5, 100), Is.True);
+        Assert.That(BigDouble.Abs(new BigDouble(5, 100)) == new BigDouble(5, 100), Is.True);
+        Assert.That(BigDouble.Abs(BigDouble.Zero) == BigDouble.Zero, Is.True);
+    }
+
+    [Test]
+    public void Negate_FlipsSign()
+    {
+        Assert.That(BigDouble.Negate(new BigDouble(5, 100)) == new BigDouble(-5, 100), Is.True);
+        Assert.That(-new BigDouble(-3) == new BigDouble(3), Is.True);
+    }
+
+    [Test]
+    public void Sign_ReturnsCorrectSign()
+    {
+        Assert.That(BigDouble.Sign(new BigDouble(5, 100)), Is.EqualTo(1));
+        Assert.That(BigDouble.Sign(new BigDouble(-5, 100)), Is.EqualTo(-1));
+        Assert.That(BigDouble.Sign(BigDouble.Zero), Is.EqualTo(0));
+    }
+
+    // ===== Reciprocate =====
+
+    [Test]
+    public void Reciprocate_Basic()
+    {
+        Assert.That(BigDouble.Reciprocate(2).Equals(new BigDouble(0.5), 1e-12), Is.True);
+        Assert.That(
+            BigDouble.Reciprocate(new BigDouble(4, 2)).Equals(new BigDouble(2.5, -3), 1e-12),
+            Is.True
+        );
+    }
+
+    [Test]
+    public void Reciprocate_HugeExponent()
+    {
+        var result = BigDouble.Reciprocate(new BigDouble(2, 1000));
+        Assert.That(
+            result.Equals(new BigDouble(5, -1001), 1e-12),
+            Is.True,
+            $"실제 {result.ToStringMantissaExponent()}"
+        );
+    }
+
+    // ===== 증감 연산자 =====
+
+    [Test]
+    public void IncrementDecrement_Operators()
+    {
+        BigDouble a = 5;
+        a++;
+        Assert.That(a == new BigDouble(6), Is.True);
+        a--;
+        a--;
+        Assert.That(a == new BigDouble(4), Is.True);
+    }
+
+    // ===== Pow 엣지 =====
+
+    [Test]
+    public void Pow_IntegerPower_Exact()
+    {
+        Assert.That(BigDouble.Pow(2, 10) == new BigDouble(1024), Is.True);
+        Assert.That(BigDouble.Pow(new BigDouble(1, 100), 2) == new BigDouble(1, 200), Is.True);
+    }
+
+    [Test]
+    public void Pow_NegativeBase_IntegerPower()
+    {
+        Assert.That(BigDouble.Pow(-2, 3.0).Equals(new BigDouble(-8), 1e-12), Is.True);
+        Assert.That(BigDouble.Pow(-2, 2.0).Equals(new BigDouble(4), 1e-12), Is.True);
+    }
+
+    [Test]
+    public void Pow_NegativeBase_FractionalPower_ReturnsNaN()
+    {
+        Assert.That(BigDouble.IsNaN(BigDouble.Pow(-4, 0.5)), Is.True);
+    }
+
+    [Test]
+    public void Pow_FractionalPower()
+    {
+        Assert.That(BigDouble.Pow(10, 0.5).Equals(BigDouble.Sqrt(10), 1e-12), Is.True);
+        Assert.That(
+            BigDouble.Pow(new BigDouble(1, 100), 0.5).Equals(new BigDouble(1, 50), 1e-9),
+            Is.True
+        );
+    }
+
+    [Test]
+    public void Pow_ZeroPower_ReturnsOne()
+    {
+        Assert.That(BigDouble.Pow(new BigDouble(7, 77), 0L) == BigDouble.One, Is.True);
+    }
+
+    [Test]
+    public void Pow_ExponentOverflow_ReturnsInfinityOrZero()
+    {
+        var huge = BigDouble.Pow10(5_000_000_000_000_000_000L);
+        Assert.That(BigDouble.IsPositiveInfinity(BigDouble.Pow(huge, 10L)), Is.True);
+
+        var tiny = BigDouble.Pow10(-5_000_000_000_000_000_000L);
+        Assert.That(BigDouble.Pow(tiny, 10L) == BigDouble.Zero, Is.True);
+    }
+
+    [Test]
+    public void Multiply_ExponentOverflow_ReturnsInfinityOrZero()
+    {
+        var huge = BigDouble.Pow10(9_000_000_000_000_000_000L);
+        Assert.That(BigDouble.IsPositiveInfinity(huge * huge), Is.True);
+
+        var tiny = BigDouble.Pow10(-9_000_000_000_000_000_000L);
+        Assert.That(tiny * tiny == BigDouble.Zero, Is.True);
+    }
+
+    [Test]
+    public void Pow10_FractionalPower()
+    {
+        Assert.That(BigDouble.Pow10(0.5).Equals(BigDouble.Sqrt(10), 1e-12), Is.True);
+        Assert.That(BigDouble.Pow10(100.0) == new BigDouble(1, 100), Is.True);
+    }
+
+    // ===== Sqrt / Cbrt =====
+
+    [Test]
+    public void Sqrt_NegativeValue_ReturnsNaN()
+    {
+        Assert.That(BigDouble.IsNaN(BigDouble.Sqrt(-4)), Is.True);
+    }
+
+    [Test]
+    public void Sqrt_HugeValue_OddExponent()
+    {
+        // sqrt(1e101) = 10^50.5 ≈ 3.162e50
+        var result = BigDouble.Sqrt(new BigDouble(1, 101));
+        Assert.That(result.Equals(new BigDouble(3.16227766016838, 50), 1e-9), Is.True);
+    }
+
+    [Test]
+    public void Cbrt_Basic()
+    {
+        Assert.That(BigDouble.Cbrt(27).Equals(new BigDouble(3), 1e-12), Is.True);
+        Assert.That(BigDouble.Cbrt(-27).Equals(new BigDouble(-3), 1e-12), Is.True);
+        Assert.That(BigDouble.Cbrt(new BigDouble(1, 3)).Equals(new BigDouble(10), 1e-12), Is.True);
+    }
+
+    [Test]
+    public void Cbrt_HugeValue_ExponentModBranches()
+    {
+        // 지수 mod 3이 0/1/2인 케이스를 모두 — log10 기준으로 검증
+        Assert.That(
+            BigDouble.Log10(BigDouble.Cbrt(new BigDouble(1, 99))),
+            Is.EqualTo(33.0).Within(1e-9)
+        );
+        Assert.That(
+            BigDouble.Log10(BigDouble.Cbrt(new BigDouble(1, 100))),
+            Is.EqualTo(100 / 3.0).Within(1e-9)
+        );
+        Assert.That(
+            BigDouble.Log10(BigDouble.Cbrt(new BigDouble(1, 101))),
+            Is.EqualTo(101 / 3.0).Within(1e-9)
+        );
+    }
+
+    // ===== Exp / Factorial =====
+
+    [Test]
+    public void Exp_Basic()
+    {
+        Assert.That(BigDouble.Exp(1).Equals(new BigDouble(Math.E), 1e-9), Is.True);
+        Assert.That(BigDouble.Exp(0).Equals(BigDouble.One, 1e-9), Is.True);
+    }
+
+    [Test]
+    public void Exp_LargeValue_MatchesLog()
+    {
+        // exp(1000)의 자연로그는 1000이어야 함
+        var result = BigDouble.Exp(1000);
+        Assert.That(BigDouble.Ln(result), Is.EqualTo(1000.0).Within(1e-6));
+    }
+
+    [Test]
+    public void Factorial_SmallValues_NearExact()
+    {
+        // 스털링 근사라 정확하지 않음 — 상대 오차로 검증
+        Assert.That(BigDouble.Factorial(5).Equals(new BigDouble(120), 1e-6), Is.True);
+        Assert.That(BigDouble.Factorial(10).Equals(new BigDouble(3628800), 1e-6), Is.True);
+    }
+
+    [Test]
+    public void Factorial_LargeValue_MatchesStirlingMagnitude()
+    {
+        // 100! ≈ 9.33e157
+        var result = BigDouble.Factorial(100);
+        Assert.That(BigDouble.Log10(result), Is.EqualTo(157.97).Within(0.01));
+    }
+
+    [Test]
+    public void Factorial_ResultExponentOverflow_ReturnsPositiveInfinity()
+    {
+        // n=1e30이면 log10(n!) ≈ 3e31로 long 지수 범위를 초과 — 포화된 가짜 값이 아니라 Infinity여야 함
+        var result = BigDouble.Factorial(new BigDouble(1, 30));
+        Assert.That(BigDouble.IsPositiveInfinity(result), Is.True, $"실제 {result}");
+    }
+
+    [Test]
+    public void Factorial_BeyondDoubleRange_ReturnsPositiveInfinity()
+    {
+        // double로 변환 불가능한 입력(1e400)은 NaN으로 붕괴하지 않고 Infinity여야 함
+        var result = BigDouble.Factorial(new BigDouble(1, 400));
+        Assert.That(BigDouble.IsPositiveInfinity(result), Is.True, $"실제 {result}");
+    }
+
+    // ===== 쌍곡함수 =====
+
+    [Test]
+    public void Hyperbolic_BasicValues()
+    {
+        Assert.That(BigDouble.Sinh(1).Equals(new BigDouble(Math.Sinh(1)), 1e-9), Is.True);
+        Assert.That(BigDouble.Cosh(1).Equals(new BigDouble(Math.Cosh(1)), 1e-9), Is.True);
+        Assert.That(BigDouble.Tanh(1).Equals(new BigDouble(Math.Tanh(1)), 1e-9), Is.True);
+    }
+
+    [Test]
+    public void InverseHyperbolic_BasicValues()
+    {
+        Assert.That(BigDouble.Asinh(1), Is.EqualTo(Math.Asinh(1)).Within(1e-9));
+        Assert.That(BigDouble.Acosh(2), Is.EqualTo(Math.Acosh(2)).Within(1e-9));
+        Assert.That(BigDouble.Atanh(0.5), Is.EqualTo(Math.Atanh(0.5)).Within(1e-9));
+    }
+
+    [Test]
+    public void Atanh_OutOfDomain_ReturnsNaN()
+    {
+        Assert.That(double.IsNaN(BigDouble.Atanh(1)), Is.True);
+        Assert.That(double.IsNaN(BigDouble.Atanh(-2)), Is.True);
+    }
+
+    // ===== 로그 변형 =====
+
+    [Test]
+    public void Log10_OutOfDomain_FollowsIeeeSemantics()
+    {
+        // 음수는 NaN, 0은 -Infinity — Math.Log10과 동일한 의미를 유지해야 한다
+        Assert.That(double.IsNaN(BigDouble.Log10(new BigDouble(-5))), Is.True);
+        Assert.That(double.IsNegativeInfinity(BigDouble.Log10(BigDouble.Zero)), Is.True);
+    }
+
+    [Test]
+    public void Log10_HugeValue()
+    {
+        Assert.That(BigDouble.Log10(new BigDouble(1, 100)), Is.EqualTo(100.0).Within(1e-12));
+        Assert.That(
+            BigDouble.Log10(new BigDouble(5, 100)),
+            Is.EqualTo(100.0 + Math.Log10(5)).Within(1e-12)
+        );
+    }
+
+    [Test]
+    public void AbsLog10_NegativeValue()
+    {
+        Assert.That(BigDouble.AbsLog10(new BigDouble(-1, 50)), Is.EqualTo(50.0).Within(1e-12));
+    }
+
+    [Test]
+    public void Log2_And_Ln()
+    {
+        Assert.That(BigDouble.Log2(8), Is.EqualTo(3.0).Within(1e-9));
+        Assert.That(BigDouble.Ln(new BigDouble(Math.E)), Is.EqualTo(1.0).Within(1e-9));
+    }
+
+    [Test]
+    public void Log_ArbitraryBase()
+    {
+        Assert.That(BigDouble.Log(100, 10.0), Is.EqualTo(2.0).Within(1e-9));
+        Assert.That(BigDouble.Log(8, 2.0), Is.EqualTo(3.0).Within(1e-9));
+        Assert.That(
+            BigDouble.Log(new BigDouble(1, 100), new BigDouble(10)),
+            Is.EqualTo(100.0).Within(1e-9)
+        );
+    }
+
+    [Test]
+    public void Log_BaseZero_ReturnsNaN()
+    {
+        Assert.That(double.IsNaN(BigDouble.Log(5, 0.0)), Is.True);
+    }
+
+    // ===== Min / Max NaN 처리 =====
+
+    [Test]
+    public void MinMax_WithNaN_ReturnsNaN()
+    {
+        Assert.That(BigDouble.IsNaN(BigDouble.Max(BigDouble.NaN, 5)), Is.True);
+        Assert.That(BigDouble.IsNaN(BigDouble.Max(5, BigDouble.NaN)), Is.True);
+        Assert.That(BigDouble.IsNaN(BigDouble.Min(BigDouble.NaN, 5)), Is.True);
+        Assert.That(BigDouble.IsNaN(BigDouble.Min(5, BigDouble.NaN)), Is.True);
+    }
+
+    // ===== 확장 메서드 =====
+
+    [Test]
+    public void ExtensionMethods_MatchStaticMethods()
+    {
+        BigDouble value = new BigDouble(2, 50);
+        Assert.That(value.Sqr() == BigDouble.Pow(value, 2L), Is.True);
+        Assert.That(value.Abs() == BigDouble.Abs(value), Is.True);
+        Assert.That(value.Sqrt() == BigDouble.Sqrt(value), Is.True);
+        Assert.That(value.Reciprocate() == BigDouble.Reciprocate(value), Is.True);
+        Assert.That(value.Sign(), Is.EqualTo(1));
+    }
+}

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/FastDoubleReviewTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/FastDoubleReviewTests.cs
@@ -1,0 +1,96 @@
+using System.Globalization;
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// FastDouble 집중 리뷰에서 발견된 버그들의 회귀 테스트
+/// </summary>
+public class FastDoubleReviewTests
+{
+    // ===== F1: maxDecimalPlaces 절삭이 지수 스케일링 전에 적용돼
+    //           지수 표기에서 정수부 유효숫자까지 깎이던 버그 =====
+
+    [Test]
+    public void ParseDouble_ExponentNotation_KeepsFullPrecision()
+    {
+        // 선행 0이 maxDecimalPlaces를 소진해 0이 반환되던 케이스
+        Assert.That(FastDouble.ParseDouble("0.0000001234567e10"), Is.EqualTo(1234.567));
+        // 최종 값에 소수부가 없는데도 12,345,670,000으로 깎이던 케이스
+        Assert.That(FastDouble.ParseDouble("1.23456789e10"), Is.EqualTo(12345678900.0));
+        Assert.That(FastDouble.ParseDouble("1.23456789e-2"), Is.EqualTo(0.0123456789));
+    }
+
+    [Test]
+    public void ParseDouble_PlainNotation_StillTruncates()
+    {
+        // 평문 십진수의 소수부 절삭(반올림 아님)은 의도된 설계
+        Assert.That(FastDouble.ParseDouble("1.9999999", 6), Is.EqualTo(1.999999));
+        Assert.That(FastDouble.ParseDouble("0.0000001", 6), Is.EqualTo(0));
+    }
+
+    // ===== F2: 숫자 없는 입력이 조용히 0/-0/1로 파싱되던 버그 =====
+
+    [Test]
+    public void ParseDouble_NoMantissaDigits_Throws()
+    {
+        Assert.Throws<FormatException>(() => FastDouble.ParseDouble("-"));
+        Assert.Throws<FormatException>(() => FastDouble.ParseDouble("+"));
+        Assert.Throws<FormatException>(() => FastDouble.ParseDouble("."));
+    }
+
+    [Test]
+    public void ParseDouble_ExponentWithoutDigits_Throws()
+    {
+        Assert.Throws<FormatException>(() => FastDouble.ParseDouble("1e"));
+        Assert.Throws<FormatException>(() => FastDouble.ParseDouble("1e-"));
+        Assert.Throws<FormatException>(() => FastDouble.ParseDouble("1e+"));
+    }
+
+    [Test]
+    public void ParseDouble_NullOrEmpty_ReturnsZero()
+    {
+        // 기존 호환 동작 유지
+        Assert.That(FastDouble.ParseDouble(""), Is.EqualTo(0));
+        Assert.That(FastDouble.ParseDouble(null), Is.EqualTo(0));
+    }
+
+    // ===== F3: OptimizeToString(0)이 culture 의존적인 느린 표준 포맷터를 타던 문제 =====
+
+    [Test]
+    public void OptimizeToString_ZeroDecimalPlaces_UsesFastPath()
+    {
+        Assert.That(1234.567.OptimizeToString(0), Is.EqualTo("1235"));
+        Assert.That((-1234.6).OptimizeToString(0), Is.EqualTo("-1235"));
+        Assert.That(0.0.OptimizeToString(0), Is.EqualTo("0"));
+        // 기존엔 ToString("0")이 "∞"를 반환해 다른 경로("Infinity")와 표기가 갈렸음
+        Assert.That(double.PositiveInfinity.OptimizeToString(0), Is.EqualTo("Infinity"));
+        Assert.That(double.NaN.OptimizeToString(0), Is.EqualTo("NaN"));
+    }
+
+    // ===== F4: 소수부가 banker's rounding이라 정수부 경로와 반올림 방식이 갈리던 문제 =====
+
+    [Test]
+    public void OptimizeToString_MidpointRoundsAwayFromZero()
+    {
+        Assert.That(0.125.OptimizeToString(2), Is.EqualTo("0.13"));
+        Assert.That(0.5.OptimizeToString(0), Is.EqualTo("1"));
+        Assert.That(2.5.OptimizeToString(0), Is.EqualTo("3"));
+    }
+
+    [Test]
+    public void OptimizeToString_ZeroValue_PadsDecimals()
+    {
+        Assert.That(0.0.OptimizeToString(3), Is.EqualTo("0.000"));
+        Assert.That((-0.001).OptimizeToString(2), Is.EqualTo("-0.00"));
+    }
+
+    // ===== F5: substring 할당 없이 파싱할 수 있는 ReadOnlySpan 오버로드 =====
+
+    [Test]
+    public void ParseDouble_SpanOverload()
+    {
+        Assert.That(FastDouble.ParseDouble("123.45".AsSpan()), Is.EqualTo(123.45));
+        Assert.That(FastDouble.ParseDouble("price:1.5e3".AsSpan(6)), Is.EqualTo(1500));
+    }
+}

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/FastDoubleTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/FastDoubleTests.cs
@@ -1,0 +1,156 @@
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// FastDouble 종합 테스트 — ParseDouble과 OptimizeToString
+/// </summary>
+public class FastDoubleTests
+{
+    // ===== ParseDouble =====
+
+    [Test]
+    public void ParseDouble_PlainInteger()
+    {
+        Assert.That(FastDouble.ParseDouble("123"), Is.EqualTo(123.0));
+        Assert.That(FastDouble.ParseDouble("0"), Is.EqualTo(0.0));
+    }
+
+    [Test]
+    public void ParseDouble_Signs()
+    {
+        Assert.That(FastDouble.ParseDouble("+5"), Is.EqualTo(5.0));
+        Assert.That(FastDouble.ParseDouble("-3.5"), Is.EqualTo(-3.5));
+        Assert.That(FastDouble.ParseDouble("-0"), Is.EqualTo(0.0));
+    }
+
+    [Test]
+    public void ParseDouble_NullOrEmpty_ReturnsZero()
+    {
+        Assert.That(FastDouble.ParseDouble(""), Is.EqualTo(0.0));
+        Assert.That(FastDouble.ParseDouble(null!), Is.EqualTo(0.0));
+    }
+
+    [Test]
+    public void ParseDouble_DecimalWithinAccuracy()
+    {
+        Assert.That(FastDouble.ParseDouble("123.456789"), Is.EqualTo(123.456789));
+    }
+
+    [Test]
+    public void ParseDouble_TruncatesBeyondMaxDecimalPlaces()
+    {
+        // 반올림이 아니라 잘라냄
+        Assert.That(FastDouble.ParseDouble("123.456789", 2), Is.EqualTo(123.45));
+        Assert.That(FastDouble.ParseDouble("1.999999999", 3), Is.EqualTo(1.999));
+    }
+
+    [Test]
+    public void ParseDouble_NegativeMaxDecimalPlaces_TreatedAsZero()
+    {
+        Assert.That(FastDouble.ParseDouble("123.456", -1), Is.EqualTo(123.0));
+    }
+
+    [Test]
+    public void ParseDouble_ExponentNotation()
+    {
+        Assert.That(FastDouble.ParseDouble("1e5"), Is.EqualTo(100000.0));
+        Assert.That(FastDouble.ParseDouble("1.5e3"), Is.EqualTo(1500.0));
+        Assert.That(FastDouble.ParseDouble("1e+5"), Is.EqualTo(100000.0));
+        Assert.That(FastDouble.ParseDouble("2e-3"), Is.EqualTo(0.002).Within(1e-18));
+    }
+
+    [TestCase("12a34")]
+    [TestCase("1.2.3")]
+    [TestCase("5e3e2")]
+    [TestCase("--5")]
+    [TestCase("1,000")]
+    public void ParseDouble_InvalidInput_ThrowsFormatException(string input)
+    {
+        Assert.Throws<FormatException>(() => FastDouble.ParseDouble(input));
+    }
+
+    [Test]
+    public void ParseDouble_RoundTripsWithBigDoubleValues()
+    {
+        // 게임 세이브 데이터 라운드트립 시나리오
+        double[] values = { 0, 1, 999.5, 12345.678901, 1e15, 5e-5 };
+        foreach (var value in values)
+        {
+            var str = value.ToString("R", System.Globalization.CultureInfo.InvariantCulture);
+            var parsed = FastDouble.ParseDouble(str, 17);
+            Assert.That(
+                parsed,
+                Is.EqualTo(value).Within(Math.Abs(value) * 1e-12 + 1e-12),
+                $"'{str}' 라운드트립 실패"
+            );
+        }
+    }
+
+    // ===== OptimizeToString =====
+
+    [Test]
+    public void OptimizeToString_BasicRounding()
+    {
+        Assert.That((1.567).OptimizeToString(2), Is.EqualTo("1.57"));
+        Assert.That((123.456).OptimizeToString(1), Is.EqualTo("123.5"));
+        Assert.That((1.234).OptimizeToString(3), Is.EqualTo("1.234"));
+    }
+
+    [Test]
+    public void OptimizeToString_CarryPropagation()
+    {
+        Assert.That((0.999999999).OptimizeToString(2), Is.EqualTo("1.00"));
+        Assert.That((1.999).OptimizeToString(2), Is.EqualTo("2.00"));
+        Assert.That((-1.999).OptimizeToString(2), Is.EqualTo("-2.00"));
+    }
+
+    [Test]
+    public void OptimizeToString_NegativeValues()
+    {
+        Assert.That((-1.25).OptimizeToString(2), Is.EqualTo("-1.25"));
+        Assert.That((-0.5).OptimizeToString(2), Is.EqualTo("-0.50"));
+    }
+
+    [Test]
+    public void OptimizeToString_Zero_PadsDecimals()
+    {
+        Assert.That((0.0).OptimizeToString(3), Is.EqualTo("0.000"));
+        Assert.That((0.0).OptimizeToString(1), Is.EqualTo("0.0"));
+    }
+
+    [Test]
+    public void OptimizeToString_ZeroDecimalPlaces()
+    {
+        Assert.That((1.9).OptimizeToString(0), Is.EqualTo("2"));
+        Assert.That((42.0).OptimizeToString(0), Is.EqualTo("42"));
+    }
+
+    [Test]
+    public void OptimizeToString_SpecialValues()
+    {
+        Assert.That(double.NaN.OptimizeToString(2), Is.EqualTo("NaN"));
+        Assert.That(double.PositiveInfinity.OptimizeToString(2), Is.EqualTo("Infinity"));
+        Assert.That(double.NegativeInfinity.OptimizeToString(2), Is.EqualTo("-Infinity"));
+    }
+
+    [Test]
+    public void OptimizeToString_HugeValue_FallsBackToStandardFormatter()
+    {
+        Assert.That((1e19).OptimizeToString(2), Is.EqualTo("10000000000000000000.00"));
+    }
+
+    [Test]
+    public void OptimizeToString_NegativeDecimalPlaces_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => (1.5).OptimizeToString(-1));
+    }
+
+    [Test]
+    public void OptimizeToString_SmallFraction_PadsLeadingZeros()
+    {
+        // 소수부 앞자리 0이 유지돼야 함 (1.05 → "1.05", "1.5" 아님)
+        Assert.That((1.05).OptimizeToString(2), Is.EqualTo("1.05"));
+        Assert.That((10.001).OptimizeToString(3), Is.EqualTo("10.001"));
+    }
+}

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/NumberUtilityTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/NumberUtilityTests.cs
@@ -1,0 +1,57 @@
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// NumberUtility.GetDigits 테스트 — 정수부 자릿수 계산
+/// </summary>
+public class NumberUtilityTests
+{
+    [TestCase(0.0, 0)]
+    [TestCase(5.0, 1)]
+    [TestCase(9.0, 1)]
+    [TestCase(10.0, 2)]
+    [TestCase(99.0, 2)]
+    [TestCase(100.0, 3)]
+    [TestCase(999.99, 3)]
+    [TestCase(1000.0, 4)]
+    public void GetDigits_PositiveValues(double value, int expected)
+    {
+        Assert.That(NumberUtility.GetDigits(value), Is.EqualTo(expected));
+    }
+
+    [TestCase(-5.0, 1)]
+    [TestCase(-99.0, 2)]
+    [TestCase(-1234.0, 4)]
+    public void GetDigits_NegativeValues_UsesAbsoluteValue(double value, int expected)
+    {
+        Assert.That(NumberUtility.GetDigits(value), Is.EqualTo(expected));
+    }
+
+    [TestCase(0.5)]
+    [TestCase(0.999)]
+    [TestCase(-0.001)]
+    public void GetDigits_FractionLessThanOne_ReturnsZero(double value)
+    {
+        Assert.That(NumberUtility.GetDigits(value), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetDigits_NaN_ReturnsZero()
+    {
+        Assert.That(NumberUtility.GetDigits(double.NaN), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetDigits_Infinity_ReturnsZero()
+    {
+        Assert.That(NumberUtility.GetDigits(double.PositiveInfinity), Is.EqualTo(0));
+        Assert.That(NumberUtility.GetDigits(double.NegativeInfinity), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetDigits_IntMaxValue()
+    {
+        Assert.That(NumberUtility.GetDigits(int.MaxValue), Is.EqualTo(10));
+    }
+}

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/RoundingTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/RoundingTests.cs
@@ -1,0 +1,147 @@
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// BigDouble 반올림 계열 함수의 분기별 테스트 — Round/Floor/Ceiling/Truncate
+/// </summary>
+public class RoundingTests
+{
+    // ===== Round =====
+
+    [Test]
+    public void Round_DefaultIsBankersRounding()
+    {
+        Assert.That(BigDouble.Round(new BigDouble(2.5)) == new BigDouble(2), Is.True);
+        Assert.That(BigDouble.Round(new BigDouble(3.5)) == new BigDouble(4), Is.True);
+    }
+
+    [Test]
+    public void Round_MidpointRoundingAwayFromZero()
+    {
+        Assert.That(
+            BigDouble.Round(new BigDouble(2.5), MidpointRounding.AwayFromZero) == new BigDouble(3),
+            Is.True
+        );
+        Assert.That(
+            BigDouble.Round(new BigDouble(-2.5), MidpointRounding.AwayFromZero)
+                == new BigDouble(-3),
+            Is.True
+        );
+    }
+
+    [Test]
+    public void Round_TinyValue_ReturnsZero()
+    {
+        // 지수 < -1이면 0
+        Assert.That(BigDouble.Round(new BigDouble(0.04)) == BigDouble.Zero, Is.True);
+        Assert.That(BigDouble.Round(new BigDouble(-0.04)) == BigDouble.Zero, Is.True);
+    }
+
+    [Test]
+    public void Round_HugeValue_Unchanged()
+    {
+        var huge = new BigDouble(1.23456, 20);
+        Assert.That(BigDouble.Round(huge) == huge, Is.True);
+    }
+
+    [Test]
+    public void Round_NaN_PassesThrough()
+    {
+        Assert.That(BigDouble.IsNaN(BigDouble.Round(BigDouble.NaN)), Is.True);
+        Assert.That(
+            BigDouble.IsNaN(BigDouble.Round(BigDouble.NaN, MidpointRounding.AwayFromZero)),
+            Is.True
+        );
+    }
+
+    // ===== Floor =====
+
+    [Test]
+    public void Floor_BasicValues()
+    {
+        Assert.That(BigDouble.Floor(new BigDouble(2.9)) == new BigDouble(2), Is.True);
+        Assert.That(BigDouble.Floor(new BigDouble(-0.5)) == new BigDouble(-1), Is.True);
+        Assert.That(BigDouble.Floor(new BigDouble(-2.1)) == new BigDouble(-3), Is.True);
+    }
+
+    [Test]
+    public void Floor_TinyValue_BranchBySign()
+    {
+        // 지수 < -1: 양수는 0, 음수는 -1
+        Assert.That(BigDouble.Floor(new BigDouble(0.05)) == BigDouble.Zero, Is.True);
+        Assert.That(BigDouble.Floor(new BigDouble(-0.05)) == -BigDouble.One, Is.True);
+    }
+
+    [Test]
+    public void Floor_HugeValue_Unchanged()
+    {
+        var huge = new BigDouble(1.5, 50);
+        Assert.That(BigDouble.Floor(huge) == huge, Is.True);
+    }
+
+    // ===== Ceiling =====
+
+    [Test]
+    public void Ceiling_BasicValues()
+    {
+        Assert.That(BigDouble.Ceiling(new BigDouble(2.1)) == new BigDouble(3), Is.True);
+        Assert.That(BigDouble.Ceiling(new BigDouble(-2.9)) == new BigDouble(-2), Is.True);
+    }
+
+    [Test]
+    public void Ceiling_TinyValue_BranchBySign()
+    {
+        // 지수 < -1: 양수는 1, 음수는 0
+        Assert.That(BigDouble.Ceiling(new BigDouble(0.05)) == BigDouble.One, Is.True);
+        Assert.That(BigDouble.Ceiling(new BigDouble(-0.05)) == BigDouble.Zero, Is.True);
+    }
+
+    [Test]
+    public void Ceiling_NaN_PassesThrough()
+    {
+        Assert.That(BigDouble.IsNaN(BigDouble.Ceiling(BigDouble.NaN)), Is.True);
+    }
+
+    // ===== Truncate =====
+
+    [Test]
+    public void Truncate_BasicValues()
+    {
+        Assert.That(BigDouble.Truncate(new BigDouble(5.7)) == new BigDouble(5), Is.True);
+        Assert.That(BigDouble.Truncate(new BigDouble(-5.7)) == new BigDouble(-5), Is.True);
+    }
+
+    [Test]
+    public void Truncate_FractionOnly_ReturnsZero()
+    {
+        // 지수 < 0이면 0 (Floor와 달리 음수도 0으로)
+        Assert.That(BigDouble.Truncate(new BigDouble(0.9)) == BigDouble.Zero, Is.True);
+        Assert.That(BigDouble.Truncate(new BigDouble(-0.9)) == BigDouble.Zero, Is.True);
+    }
+
+    [Test]
+    public void Truncate_HugeValue_Unchanged()
+    {
+        var huge = new BigDouble(9.87654, 30);
+        Assert.That(BigDouble.Truncate(huge) == huge, Is.True);
+    }
+
+    [Test]
+    public void Truncate_NaN_PassesThrough()
+    {
+        Assert.That(BigDouble.IsNaN(BigDouble.Truncate(BigDouble.NaN)), Is.True);
+    }
+
+    // ===== 게임 시나리오: 구매 개수 내림 =====
+
+    [Test]
+    public void Floor_PurchaseCountScenario()
+    {
+        // 보유 재화 / 가격 → 구매 가능 개수 내림
+        BigDouble money = new BigDouble(9.99, 5); // 999,000
+        BigDouble price = new BigDouble(1, 5); // 100,000
+        var count = BigDouble.Floor(money / price);
+        Assert.That(count == new BigDouble(9), Is.True, $"기대 9, 실제 {count}");
+    }
+}

--- a/src/dotnet/LD.Numeric/LD.Numeric.Test/ToStringFormattingTests.cs
+++ b/src/dotnet/LD.Numeric/LD.Numeric.Test/ToStringFormattingTests.cs
@@ -1,0 +1,85 @@
+using LD.Numeric.IdleNumber;
+
+namespace LD.Numeric.Test;
+
+/// <summary>
+/// BigDouble.ToString 포맷 규칙 테스트 — 자릿수별 소수점 표시와 알파벳 단위
+/// </summary>
+public class ToStringFormattingTests
+{
+    [Test]
+    public void ToString_Zero()
+    {
+        Assert.That(BigDouble.Zero.ToString(), Is.EqualTo("0"));
+    }
+
+    [Test]
+    public void ToString_SmallIntegers_NoDecimals()
+    {
+        // 지수 2 이하 + 가수 한 자리면 소수점 없이 표시
+        Assert.That(new BigDouble(7).ToString(), Is.EqualTo("7"));
+        Assert.That(new BigDouble(12).ToString(), Is.EqualTo("12"));
+        Assert.That(new BigDouble(999).ToString(), Is.EqualTo("999"));
+    }
+
+    [Test]
+    public void ToString_ThousandsRange_TwoDecimalsWithUnit()
+    {
+        // 조정 가수가 한 자리(1~9)면 소수 2자리
+        Assert.That(new BigDouble(1234).ToString(), Is.EqualTo("1.23A"));
+        Assert.That(new BigDouble(5000).ToString(), Is.EqualTo("5.00A"));
+    }
+
+    [Test]
+    public void ToString_TenThousandsRange_OneDecimalWithUnit()
+    {
+        // 조정 가수가 두 자리(10~99)면 소수 1자리
+        Assert.That(new BigDouble(12345).ToString(), Is.EqualTo("12.3A"));
+    }
+
+    [Test]
+    public void ToString_HundredThousandsRange_NoDecimalsWithUnit()
+    {
+        // 조정 가수가 세 자리(100~999)면 소수점 없음
+        Assert.That(new BigDouble(123456).ToString(), Is.EqualTo("123A"));
+    }
+
+    [Test]
+    public void ToString_MillionRange_NextUnit()
+    {
+        Assert.That(new BigDouble(1, 6).ToString(), Is.EqualTo("1.00B"));
+        Assert.That(new BigDouble(2.5, 9).ToString(), Is.EqualTo("2.50C"));
+    }
+
+    [Test]
+    public void ToString_NegativeValue_KeepsSign()
+    {
+        Assert.That(new BigDouble(-1234).ToString(), Is.EqualTo("-1.23A"));
+        Assert.That(new BigDouble(-12).ToString(), Is.EqualTo("-12"));
+    }
+
+    [Test]
+    public void ToString_LessThanOne_PlainDoubleFormat()
+    {
+        Assert.That(new BigDouble(0.5).ToString(), Is.EqualTo("0.5"));
+        Assert.That(new BigDouble(0.001).ToString(), Is.EqualTo("0.001"));
+    }
+
+    [Test]
+    public void ToString_HugeExponent_UsesLongAlphabetUnit()
+    {
+        // 지수 1000 → index 1000/3-1 = 332
+        var expected = AlphabetManager.GetAlphabetUnit(1000 / 3 - 1);
+        var str = new BigDouble(1.5, 1000).ToString();
+        Assert.That(str, Does.EndWith(expected));
+        Assert.That(str, Does.StartWith("1"));
+    }
+
+    [Test]
+    public void ToString_MantissaRoundsToThreeDecimals()
+    {
+        // 가수는 소수 3자리로 반올림된 뒤 포맷됨
+        Assert.That(new BigDouble(1.2341234, 3).ToString(), Is.EqualTo("1.23A"));
+        Assert.That(new BigDouble(1.9991234, 3).ToString(), Is.EqualTo("2.00A"));
+    }
+}

--- a/src/unity/Assets/LD.Numeric/Runtime/Converters/Converter.NumberToAlphabet/AlphabetConverter.cs
+++ b/src/unity/Assets/LD.Numeric/Runtime/Converters/Converter.NumberToAlphabet/AlphabetConverter.cs
@@ -14,6 +14,17 @@ namespace LD.Numeric.IdleNumber
         /// </summary>
         public static long GetExponent(double value)
         {
+            // Log10이 0/음수에서 -Inf/NaN을 내고 long 캐스팅에서 포화돼 쓰레기 지수가 됨.
+            // BigInteger 버전(BigInteger.Log10이 throw)과 동작을 맞춘다
+            if (double.IsNaN(value) || value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value,
+                    "지수는 양수에 대해서만 계산할 수 있습니다."
+                );
+            }
+
             var exponent = (long)(Math.Log10(value) / ExponentUnit) * ExponentUnit;
             // Math.Log10(1e21)이 20.999...로 나오는 플랫폼에서 단위가 한 단계 어긋나는 것 보정
             if (value / Math.Pow(10, exponent) >= 1000)
@@ -26,7 +37,13 @@ namespace LD.Numeric.IdleNumber
         // int, float, long은 암묵적으로 double로 변환되어 위 메서드 사용
         public static long GetExponent(BigInteger value)
         {
-            return (long)(BigInteger.Log10(value) / ExponentUnit) * ExponentUnit;
+            var exponent = (long)(BigInteger.Log10(value) / ExponentUnit) * ExponentUnit;
+            // double 버전과 같은 보정 — Log10(10^30)이 29.999...로 나오면 단위가 한 단계 어긋남
+            if (value / BigInteger.Pow(10, (int)exponent) >= 1000)
+            {
+                exponent += ExponentUnit;
+            }
+            return exponent;
         }
 
         #region 알파벳포함값 => 일반값 역함수

--- a/src/unity/Assets/LD.Numeric/Runtime/Converters/Converter.NumberToAlphabet/AlphabetConverter.cs
+++ b/src/unity/Assets/LD.Numeric/Runtime/Converters/Converter.NumberToAlphabet/AlphabetConverter.cs
@@ -85,12 +85,25 @@ namespace LD.Numeric.IdleNumber
 
         public static string ConvertToAlphabetUnit(this double number, int maxDecimalPoint = 2)
         {
+            if (double.IsNaN(number) || double.IsInfinity(number))
+                return number.ToString(CultureInfo.InvariantCulture);
+
+            // 음수는 절대값 기준으로 단위를 붙이고 부호를 복원 (기존엔 단위가 아예 안 붙었음)
+            if (number < 0)
+                return "-" + ConvertToAlphabetUnit(-number, maxDecimalPoint);
+
             if (number < 1000)
                 return number.ToString(CultureInfo.InvariantCulture);
 
             long exponent = GetExponent(number);
             double divisor = Math.Pow(10, exponent);
-            double newNumber = number / divisor;
+            double newNumber = Math.Round(number / divisor, maxDecimalPoint);
+            // 반올림이 단위 경계(1000)에 도달하면 단위를 한 칸 올림 (999999 → 1.00B)
+            if (newNumber >= 1000)
+            {
+                newNumber /= 1000;
+                exponent += ExponentUnit;
+            }
             string unit = AlphabetManager.GetAlphabetUnitFromExponent(exponent);
             return $"{newNumber.ToString($"F{maxDecimalPoint}", CultureInfo.InvariantCulture)}{unit}";
         }

--- a/src/unity/Assets/LD.Numeric/Runtime/Converters/Converter.NumberToAlphabet/AlphabetManager.cs
+++ b/src/unity/Assets/LD.Numeric/Runtime/Converters/Converter.NumberToAlphabet/AlphabetManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 
 namespace LD.Numeric.IdleNumber
@@ -36,6 +37,11 @@ namespace LD.Numeric.IdleNumber
             long index = 0;
             foreach (char c in unit)
             {
+                // 소문자/공백이 c-'A' 계산을 그대로 타면 쓰레기 지수가 됨 ("1.5a" → 1.5e99)
+                if (c < 'A' || c > 'Z')
+                {
+                    throw new FormatException("알파벳 단위는 대문자 A~Z만 허용됩니다 => " + unit);
+                }
                 index = index * 26 + (c - 'A' + 1);
             }
 

--- a/src/unity/Assets/LD.Numeric/Runtime/Optimizer/FastDouble.cs
+++ b/src/unity/Assets/LD.Numeric/Runtime/Optimizer/FastDouble.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Globalization;
-using Cysharp.Text;
 
 namespace LD.Numeric.IdleNumber
 {
@@ -43,11 +42,15 @@ namespace LD.Numeric.IdleNumber
         }
 
         /// <summary>
-        /// 스트링을 더블로 변환함
+        /// 스트링을 더블로 변환함. null/빈 문자열은 0을 반환하고,
+        /// 그 외에 숫자가 하나도 없는 입력("-", ".", "1e" 등)은 FormatException을 던진다.
         /// </summary>
-        /// <param name="s">스트링</param>
-        /// <param name="maxDecimalPlaces">최대 소수점. 정확도의 개념임.</param>
-        /// <returns></returns>
+        /// <param name="s">스트링 (invariant 표기만 허용, 공백·천 단위 구분자 불가)</param>
+        /// <param name="maxDecimalPlaces">
+        /// 초과하는 소수 자릿수는 반올림 없이 절삭된다. 정확도를 버리고 속도를 얻는 손잡이.
+        /// 지수 표기(e/E) 입력에는 적용되지 않음 — 리터럴 자릿수 기준 절삭이라 지수 스케일링을
+        /// 거치면 정수부 유효숫자까지 깎이기 때문에 전체 정밀도로 파싱한다.
+        /// </param>
         /// <exception cref="FormatException"></exception>
         public static double ParseDouble(string s, int maxDecimalPlaces = 6)
         {
@@ -55,8 +58,24 @@ namespace LD.Numeric.IdleNumber
             {
                 return 0;
             }
+            return ParseDouble(s.AsSpan(), maxDecimalPlaces);
+        }
+
+        /// <summary>
+        /// substring 할당 없이 파싱할 수 있는 오버로드.
+        /// 동작은 <see cref="ParseDouble(string, int)"/>와 동일하다.
+        /// </summary>
+        public static double ParseDouble(ReadOnlySpan<char> s, int maxDecimalPlaces = 6)
+        {
+            if (s.IsEmpty)
+            {
+                return 0;
+            }
             if (maxDecimalPlaces < 0)
                 maxDecimalPlaces = 0;
+            if (s.IndexOfAny('e', 'E') >= 0)
+                maxDecimalPlaces = int.MaxValue;
+
             bool isNegative = s[0] == '-';
             int startIndex = isNegative || s[0] == '+' ? 1 : 0;
 
@@ -65,6 +84,8 @@ namespace LD.Numeric.IdleNumber
             bool negativeExponent = false;
             bool hasExponent = false;
             bool hasDecimal = false;
+            bool hasMantissaDigits = false;
+            bool hasExponentDigits = false;
             int decimalPlaces = 0;
 
             for (int i = startIndex; i < s.Length; i++)
@@ -74,20 +95,21 @@ namespace LD.Numeric.IdleNumber
                 {
                     if (hasExponent)
                     {
+                        hasExponentDigits = true;
                         // int 오버플로 랩어라운드 방지 — 이 크기면 결과는 어차피 0 또는 Infinity
                         if (exponent < 100_000_000)
                             exponent = exponent * 10 + (c - '0');
                     }
-                    else if (decimalPlaces < maxDecimalPlaces || !hasDecimal)
+                    else
                     {
-                        mantissa = mantissa * 10.0 + (c - '0');
-                        if (hasDecimal)
-                            decimalPlaces++;
-                    }
-                    else if (decimalPlaces >= maxDecimalPlaces)
-                    {
-                        // maxDecimalPlaces 초과 숫자는 무시하되 루프는 계속 (지수부 파싱 필요)
-                        continue;
+                        hasMantissaDigits = true;
+                        if (!hasDecimal || decimalPlaces < maxDecimalPlaces)
+                        {
+                            mantissa = mantissa * 10.0 + (c - '0');
+                            if (hasDecimal)
+                                decimalPlaces++;
+                        }
+                        // maxDecimalPlaces 초과 소수 자릿수는 절삭
                     }
                 }
                 else if (c == '.' && !hasDecimal && !hasExponent)
@@ -106,26 +128,32 @@ namespace LD.Numeric.IdleNumber
                 }
                 else
                 {
-                    throw new FormatException("입력값이 잘못 됨 => " + s);
+                    throw new FormatException("입력값이 잘못 됨 => " + s.ToString());
                 }
             }
 
-            if (hasDecimal)
+            // "-", ".", "1e" 같은 입력이 조용히 0/1로 로드되는 것을 막는다
+            if (!hasMantissaDigits || (hasExponent && !hasExponentDigits))
             {
-                mantissa /= Pow10(decimalPlaces);
+                throw new FormatException("입력값이 잘못 됨 => " + s.ToString());
             }
 
-            if (hasExponent)
+            // 소수부 보정과 지수를 합쳐 곱셈/나눗셈 한 번으로 처리 — 이중 반올림 방지
+            int netExponent =
+                (hasExponent ? (negativeExponent ? -exponent : exponent) : 0) - decimalPlaces;
+            if (netExponent > 0)
             {
-                mantissa *= Pow10(negativeExponent ? -exponent : exponent);
+                mantissa *= Pow10(netExponent);
+            }
+            else if (netExponent < 0)
+            {
+                mantissa /= Pow10(-netExponent);
             }
             return isNegative ? -mantissa : mantissa;
         }
 
         public static string OptimizeToString(this double value, int decimalPlaces)
         {
-            if (decimalPlaces == 0)
-                return value.ToString("0");
             if (decimalPlaces < 0)
                 throw new ArgumentOutOfRangeException(
                     nameof(decimalPlaces),
@@ -136,15 +164,6 @@ namespace LD.Numeric.IdleNumber
                 return "NaN";
             if (double.IsInfinity(value))
                 return value > 0 ? "Infinity" : "-Infinity";
-            if (value == 0)
-            {
-                using (var sb = ZString.CreateStringBuilder())
-                {
-                    sb.Append("0.");
-                    sb.Append('0', decimalPlaces);
-                    return sb.ToString();
-                }
-            }
             // long 캐스팅 범위를 벗어나는 값은 표준 포맷터로 처리
             if (Math.Abs(value) >= 9.2e18 || decimalPlaces > 17)
             {
@@ -159,9 +178,17 @@ namespace LD.Numeric.IdleNumber
                 value = -value;
             }
 
+            if (decimalPlaces == 0)
+            {
+                long rounded = (long)Math.Round(value, MidpointRounding.AwayFromZero);
+                pos += IntegerToString(rounded, buffer.Slice(pos));
+                return buffer.Slice(0, pos).ToString();
+            }
+
             long integerPart = (long)value;
             double scale = Pow10(decimalPlaces);
-            long fraction = (long)Math.Round((value - integerPart) * scale);
+            long fraction = (long)
+                Math.Round((value - integerPart) * scale, MidpointRounding.AwayFromZero);
             // 소수부 반올림이 자리올림되면 정수부로 캐리 (예: 1.999 → 2.00)
             if (fraction >= (long)scale)
             {

--- a/src/unity/Assets/LD.Numeric/Runtime/Type/BigDouble/BigDouble.Convert.cs
+++ b/src/unity/Assets/LD.Numeric/Runtime/Type/BigDouble/BigDouble.Convert.cs
@@ -59,10 +59,32 @@ namespace LD.Numeric.IdleNumber
         /// <returns></returns>
         public double AdjustedMantissa()
         {
+            // 음수 지수엔 알파벳 단위가 없음 — 3자리 보정을 적용하면 0.5가 500이 됨
+            if (Exponent < 0)
+            {
+                return ToDouble();
+            }
+
             double roundedMantissa = Math.Round(mantissa, FractionalPartAccuracy);
             long mod = ((Exponent % ExponentUnit) + ExponentUnit) % ExponentUnit;
             double mul = Math.Pow(10, mod);
             return roundedMantissa * mul;
+        }
+
+        /// <summary>
+        /// 표시용 (가수, 지수) 쌍. 반올림이 단위 경계(1000)에 도달하면 단위를 한 칸 올린다.
+        /// (예: 9.999999e23 → 가수 1000이 아니라 가수 1 + 지수 26)
+        /// </summary>
+        private (double mantissa, long exponent) AdjustedMantissaForDisplay()
+        {
+            var adjusted = Math.Round(AdjustedMantissa(), 3);
+            var displayExponent = exponent;
+            if (adjusted >= 1000 || adjusted <= -1000)
+            {
+                adjusted /= 1000;
+                displayExponent += ExponentUnit;
+            }
+            return (adjusted, displayExponent);
         }
     }
 }

--- a/src/unity/Assets/LD.Numeric/Runtime/Type/BigDouble/BigDouble.Ctor.cs
+++ b/src/unity/Assets/LD.Numeric/Runtime/Type/BigDouble/BigDouble.Ctor.cs
@@ -12,6 +12,11 @@ namespace LD.Numeric.IdleNumber
 
         public BigDouble(string value, eFormat format)
         {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
             switch (format)
             {
                 case eFormat.Number:
@@ -31,6 +36,11 @@ namespace LD.Numeric.IdleNumber
 
         public BigDouble(string value)
         {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
             if (value.IndexOf('e') != -1 || value.IndexOf('E') != -1)
             {
                 this = new BigDouble(value, eFormat.NumberWithExponent);

--- a/src/unity/Assets/LD.Numeric/Runtime/Type/BigDouble/BigDouble.cs
+++ b/src/unity/Assets/LD.Numeric/Runtime/Type/BigDouble/BigDouble.cs
@@ -161,6 +161,13 @@ namespace LD.Numeric.IdleNumber
 
         public static BigDouble Parse(string value)
         {
+            // CompareTo(null)/Equals(null)도 implicit string 변환을 타고 여기로 와서
+            // NRE 대신 명확한 예외를 던지게 한다
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
             if (value.IndexOf('e') != -1 || value.IndexOf('E') != -1)
             {
                 var info = BigValueInfo.ExponentFormatToBigValueInfo(value);
@@ -216,7 +223,9 @@ namespace LD.Numeric.IdleNumber
             }
 
             var resultrounded = Math.Round(result);
-            if (Math.Abs(resultrounded - result) < 1e-10)
+            // 절대 임계값(1e-10)만으로는 1e8 이상 정수의 정규화 오차(상대 ~1e-16)를 못 잡아서
+            // 123456789가 123456788.99999999로 돌아옴. 상대 임계값(수 ulp 수준)을 함께 사용
+            if (Math.Abs(resultrounded - result) < Math.Max(1e-10, Math.Abs(result) * 1e-15))
                 return resultrounded;
             return result;
         }
@@ -890,6 +899,15 @@ namespace LD.Numeric.IdleNumber
 
             var n = value.ToDouble() + 1;
 
+            // 결과 지수 log10(n!) ≈ n·(log10 n − log10 e)가 long 범위를 넘으면 표현 불가.
+            // 방치하면 Pow 내부의 double→long 포화 캐스팅이 가짜 유한값을 만들어냄
+            if (
+                double.IsPositiveInfinity(n) || (n > 1 && n * (Math.Log10(n) - 1 / Ln10) > ExpLimit)
+            )
+            {
+                return PositiveInfinity;
+            }
+
             return Pow(
                     n
                         / 2.71828182845904523536
@@ -1091,6 +1109,12 @@ namespace LD.Numeric.IdleNumber
         {
             var actualStart = priceStart * BigDouble.Pow(priceRatio, currentOwned);
 
+            // 비율 1은 고정가라 등비 공식이 성립하지 않음 (log10(1) 나눗셈 → NaN)
+            if (priceRatio == BigDouble.One)
+            {
+                return BigDouble.Floor(resourcesAvailable / actualStart);
+            }
+
             //return Math.floor(log10(((resourcesAvailable / (priceStart * Math.pow(priceRatio, currentOwned))) * (priceRatio - 1)) + 1) / log10(priceRatio));
 
             return BigDouble.Floor(
@@ -1111,6 +1135,12 @@ namespace LD.Numeric.IdleNumber
         )
         {
             var actualStart = priceStart * BigDouble.Pow(priceRatio, currentOwned);
+
+            // 비율 1은 고정가 — 등비 공식은 0/0이 됨
+            if (priceRatio == BigDouble.One)
+            {
+                return actualStart * numItems;
+            }
 
             return actualStart * (1 - BigDouble.Pow(priceRatio, numItems)) / (1 - priceRatio);
         }

--- a/src/unity/Assets/LD.Numeric/Runtime/Type/BigDouble/BigDouble.cs
+++ b/src/unity/Assets/LD.Numeric/Runtime/Type/BigDouble/BigDouble.cs
@@ -108,6 +108,19 @@ namespace LD.Numeric.IdleNumber
             {
                 mantissa = mantissa / PowersOf10.Lookup(tempExponent);
             }
+
+            // subnormal 구간(~1e-323)에선 Log10이 1 어긋나 mantissa가 [1,10)을 벗어남
+            var absMantissa = Math.Abs(mantissa);
+            if (absMantissa >= 10)
+            {
+                mantissa /= 10;
+                tempExponent++;
+            }
+            else if (absMantissa < 1)
+            {
+                mantissa *= 10;
+                tempExponent--;
+            }
             return FromMantissaExponentNoNormalize(mantissa, exponent + tempExponent);
         }
 
@@ -239,15 +252,14 @@ namespace LD.Numeric.IdleNumber
                 return ToDouble().ToString(CultureInfo.InvariantCulture);
             }
 
-            var adjustedMantissa = AdjustedMantissa();
-            adjustedMantissa = Math.Round(adjustedMantissa, 3);
-            if (exponent < 3)
+            var (adjustedMantissa, displayExponent) = AdjustedMantissaForDisplay();
+            if (displayExponent < 3)
             {
                 return adjustedMantissa.OptimizeToString(decimalCount);
             }
 
             return adjustedMantissa.OptimizeToString(decimalCount)
-                + AlphabetManager.GetAlphabetUnitFromExponent(this.exponent);
+                + AlphabetManager.GetAlphabetUnitFromExponent(displayExponent);
         }
 
         public string ToStringMantissaExponent()
@@ -257,8 +269,7 @@ namespace LD.Numeric.IdleNumber
 
         public override string ToString()
         {
-            var adjustedMantissa = AdjustedMantissa();
-            adjustedMantissa = Math.Round(adjustedMantissa, 3);
+            var (adjustedMantissa, _) = AdjustedMantissaForDisplay();
             var digits = NumberUtility.GetDigits(adjustedMantissa);
             int decimalCount = 0;
             switch (digits)
@@ -466,6 +477,10 @@ namespace LD.Numeric.IdleNumber
             }
             catch (OverflowException)
             {
+                // NaN의 지수는 long.MinValue 센티널이라 여기로 흘러올 수 있음 — Zero로 둔갑 방지
+                if (IsNaN(left) || IsNaN(right))
+                    return NaN;
+
                 // 덧셈 오버플로는 두 지수의 부호가 같을 때만 발생 — 양수 방향이면 Infinity, 음수 방향이면 Zero
                 bool positiveResult = (left.Mantissa > 0) == (right.Mantissa > 0);
                 if (left.Exponent > 0)
@@ -599,6 +614,11 @@ namespace LD.Numeric.IdleNumber
 
         public override int GetHashCode()
         {
+            // Equals는 mantissa 0이면 지수를 무시하므로 해시도 지수를 무시해야 계약이 성립
+            if (IsZero(Mantissa))
+            {
+                return 0;
+            }
             unchecked
             {
                 return (Mantissa.GetHashCode() * 397) ^ Exponent.GetHashCode();
@@ -768,7 +788,8 @@ namespace LD.Numeric.IdleNumber
 
         public static double Log(BigDouble value, double @base)
         {
-            if (IsZero(@base))
+            // Math.Log(x, newBase)와 동일하게 base 0/1은 정의되지 않음 (1은 0으로 나누기가 됨)
+            if (IsZero(@base) || @base == 1)
             {
                 return double.NaN;
             }
@@ -816,7 +837,9 @@ namespace LD.Numeric.IdleNumber
             {
                 // TODO: This is rather dumb, but works anyway
                 // Power is too big for our mantissa, so we do multiple Pow with smaller powers.
-                return Pow(Pow(value, 2), (double)power / 2);
+                // 제곱하는 순간 음수 밑의 부호가 사라지므로 홀수 거듭제곱이면 복원
+                var result = Pow(Pow(value, 2), (double)power / 2);
+                return value.Mantissa < 0 && (power & 1) == 1 ? -result : result;
             }
 
             // Exponent 오버플로우 방어
@@ -827,6 +850,10 @@ namespace LD.Numeric.IdleNumber
             }
             catch (OverflowException)
             {
+                // NaN의 지수는 long.MinValue 센티널이라 여기로 흘러올 수 있음 — Zero로 둔갑 방지
+                if (IsNaN(value))
+                    return NaN;
+
                 bool positiveResult = mantissa > 0;
                 bool exponentPositive =
                     (value.Exponent > 0 && power > 0) || (value.Exponent < 0 && power < 0);
@@ -952,15 +979,16 @@ namespace LD.Numeric.IdleNumber
 
             var newmantissa = sign * Math.Pow(mantissa, 1 / 3.0);
 
-            var mod = value.Exponent % 3;
-            if (mod == 1 || mod == -1)
+            // floor(e/3) 분해와 짝을 이루는 나머지는 항상 0..2여야 함 — C#의 %는 음수에서
+            // 음수 나머지를 줘서 10^(1/3)과 10^(2/3) 보정이 서로 뒤바뀌었음 (예: 1e-4)
+            var mod = ((value.Exponent % 3) + 3) % 3;
+            if (mod == 1)
             {
                 return Normalize(newmantissa * CubeRoot10, (long)Math.Floor(value.Exponent / 3.0));
             }
 
-            if (mod != 0)
+            if (mod == 2)
             {
-                // mod != 0 여기서는 'mod == 2 || mod == -2'를 의미
                 return Normalize(
                     newmantissa * TwoThirdsPowerOf10,
                     (long)Math.Floor(value.Exponent / 3.0)

--- a/src/unity/Assets/LD.Numeric/Runtime/Utils/NumberUtility.cs
+++ b/src/unity/Assets/LD.Numeric/Runtime/Utils/NumberUtility.cs
@@ -6,6 +6,12 @@ namespace LD.Numeric.IdleNumber
     {
         public static int GetDigits(double value)
         {
+            // (int)Infinity는 int.MinValue가 되고 Math.Abs(int.MinValue)는 OverflowException
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                return 0;
+            }
+
             int digits = 0;
             int number = Math.Abs((int)value);
             while (number > 0)

--- a/src/unity/Assets/LD.Numeric/Runtime/Utils/NumberUtility.cs
+++ b/src/unity/Assets/LD.Numeric/Runtime/Utils/NumberUtility.cs
@@ -12,12 +12,22 @@ namespace LD.Numeric.IdleNumber
                 return 0;
             }
 
-            int digits = 0;
-            int number = Math.Abs((int)value);
-            while (number > 0)
+            value = Math.Abs(value);
+            if (value < 1)
             {
-                number /= 10;
+                return 0;
+            }
+
+            // int 캐스팅은 ±21억 밖에서 포화/크래시 — Log10 기반으로 double 전 범위 처리
+            int digits = (int)Math.Floor(Math.Log10(value)) + 1;
+            // Log10 경계 오차 보정 (예: Log10(1000)이 2.999... 또는 3.000...1로 나오는 경우)
+            if (Math.Pow(10, digits) <= value)
+            {
                 digits++;
+            }
+            else if (Math.Pow(10, digits - 1) > value)
+            {
+                digits--;
             }
 
             return digits;


### PR DESCRIPTION
## 개요

라이브러리 전체(BigDouble 코어/수학 함수/변환·파싱/알파벳 변환기)를 영역별로 나눠 전수 점검하고, **실증 재현된 버그 14건**을 수정했습니다. 모든 버그는 수정 전 실패하는 회귀 테스트를 먼저 작성해 확인했습니다(테스트 15건 추가, 전체 395건 통과).

> 참고: 로컬 SDK가 9.0이라 net10.0 타겟 테스트 프로젝트를 직접 실행할 수 없어, Runtime 소스+테스트 전체를 net9.0 하니스로 컴파일해 검증했습니다. 베이스라인으로 이전 리뷰 세션의 미커밋 수정(FastDouble 파서 등)도 함께 포함되어 있습니다.

## 카테고리 1 — BigDouble 수치 연산 (wrong-value)

| # | 버그 | 증상 |
|---|------|------|
| 1 | Cbrt 음수 지수 | C# `%`의 음수 나머지로 10^(1/3)·10^(2/3) 보정이 뒤바뀜 — `Cbrt(1e-4)` = 0.0215 (참값 0.0464). 3의 배수가 아닌 음수 지수 전부 오답 |
| 2 | Normalize subnormal | ~1e-323 구간에서 Log10 오차로 mantissa≥10 비정규 값 생성 → `ToDouble()`이 한 자릿수 어긋남 |
| 3 | Multiply NaN 전파 | NaN 지수(long.MinValue) 오버플로 핸들러가 `NaN × 0.5` → **0** 반환 |
| 4 | Pow NaN 전파 | 같은 원인으로 `Pow(NaN, 2L)` → **0** 반환 |
| 5 | Pow 부호 소실 | `Pow(-9, 401L)`이 mantissa 오버플로 재귀(제곱 후 반복)에서 부호를 잃고 **양수** 반환 |
| 6 | Log(x, base=1) | 0으로 나누기를 타고 Infinity 반환 (`Math.Log`는 NaN) |
| 7 | GetHashCode 계약 | 비정규 zero에서 `Equals`==true인데 해시가 다름 |

## 카테고리 2 — 표시/알파벳 변환 (display/wrong-value)

| # | 버그 | 증상 |
|---|------|------|
| 8 | ToString 반올림 캐리 | 가수 반올림이 1000에 도달해도 단위 미상승 — `9.999999e23` → "1000G" (수정 후 "1.00H") |
| 9 | ConvertToAlphabetUnit 캐리 | 같은 부류 — `999999` → "1000.00A" (수정 후 "1.00B") |
| 10 | 음수 단위 누락 | `-5000` → "-5000" (수정 후 "-5.00A") — BigDouble.ToString 경로와 불일치했음 |
| 11 | 소문자 단위 | `ConvertFromAlphabetUnit("1.5a")` → **1.5e99** (c-'A' 계산을 그대로 탐) → FormatException으로 |
| 12 | AdjustedMantissa 음수 지수 | public API인데 0.5를 500으로 반환 → 실제 값 반환으로 |

## 카테고리 3 — 유틸리티 (crash)

| # | 버그 | 증상 |
|---|------|------|
| 13 | GetDigits 크래시 | `GetDigits(-3e9)` → int 포화 후 `Math.Abs(int.MinValue)`로 **OverflowException** |
| 14 | GetDigits 오답 | 21억 초과 값이 항상 10자리로 계산 — Log10 기반으로 전 범위 처리 |

## 검증

- 4개 영역 병렬 리뷰 + 발견 버그 전건 실행 재현 후 수정
- TDD: 회귀 테스트 15건 RED 확인 → 수정 → 전체 **395/395 통과**
- csharpier 포맷 검사 통과

## 무혐의 확인 (참고)

비교 연산자 대칭성/추이성, Add 정밀도 팩터, Sqrt 음수 지수, 음수 밑 Pow(double 오버로드), Floor/Ceiling/Round 음수 지수 경계, 알파벳 26진법 자리올림(0~1000 전수), 캐시 스레드 안전성(ConcurrentDictionary), e-포맷 파서 엣지 — 전부 실측으로 정상 확인.